### PR TITLE
Enable single threading on FUSE requests temporarily

### DIFF
--- a/fuse/fuse.go
+++ b/fuse/fuse.go
@@ -68,9 +68,10 @@ func (fs *FileSystem) Store() *litefs.Store { return fs.store }
 func (fs *FileSystem) Mount() (err error) {
 	// Create FUSE server and mount it.
 	fs.server, err = fuse.NewServer(fs, fs.path, &fuse.MountOptions{
-		Name:        "litefs",
-		Debug:       fs.Debug,
-		EnableLocks: true,
+		Name:           "litefs",
+		Debug:          fs.Debug,
+		EnableLocks:    true,
+		SingleThreaded: true, // TODO: Remove; Release() is causing an unexpected race error
 	})
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/superfly/litefs
 go 1.18
 
 require (
-	github.com/hanwen/go-fuse/v2 v2.1.0
+	github.com/hanwen/go-fuse/v2 v2.1.1-0.20220627082937-d01fda7edf17
 	github.com/hashicorp/consul/api v1.11.0
 	github.com/mattn/go-sqlite3 v1.14.12
 	github.com/prometheus/client_golang v1.12.2

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/hanwen/go-fuse v1.0.0/go.mod h1:unqXarDXqzAk0rt98O2tVndEPIpUgLD9+rwFisZH3Ok=
 github.com/hanwen/go-fuse/v2 v2.1.0 h1:+32ffteETaLYClUj0a3aHjZ1hOPxxaNEHiZiujuDaek=
 github.com/hanwen/go-fuse/v2 v2.1.0/go.mod h1:oRyA5eK+pvJyv5otpO/DgccS8y/RvYMaO00GgRLGryc=
+github.com/hanwen/go-fuse/v2 v2.1.1-0.20220627082937-d01fda7edf17 h1:fOTuYWxywhaliwMobGTP/6NUCgGdal6pCpuch4MHCnU=
+github.com/hanwen/go-fuse/v2 v2.1.1-0.20220627082937-d01fda7edf17/go.mod h1:B1nGE/6RBFyBRC1RRnf23UpwCdyJ31eukw34oAKukAc=
 github.com/hashicorp/consul/api v1.11.0 h1:Hw/G8TtRvOElqxVIhBzXciiSTbapq8hZ2XKZsXk5ZCE=
 github.com/hashicorp/consul/api v1.11.0/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=
 github.com/hashicorp/consul/sdk v0.8.0 h1:OJtKBtEjboEZvG6AOUdh4Z1Zbyu0WcxQ0qatRrZHTVU=


### PR DESCRIPTION
Running `-race` on the `fuse` tests causes an unexpected race detector error. It seems to have an issue with the `fs.mu.Lock()` call in `Release()` and I'm not entirely sure why. I'm setting the mount options to be single-threaded for now while we do other testing.

```
==================
WARNING: DATA RACE
Read at 0x00c00011c420 by goroutine 9:
  runtime.racereadrange()
      <autogenerated>:1 +0x1b
  github.com/hanwen/go-fuse/v2/fuse.doLookup()
      /home/vagrant/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.1.1-0.20220627082937-d01fda7edf17/fuse/opcode.go:342 +0x14a
  github.com/hanwen/go-fuse/v2/fuse.(*Server).handleRequest()
      /home/vagrant/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.1.1-0.20220627082937-d01fda7edf17/fuse/server.go:514 +0x555
  github.com/hanwen/go-fuse/v2/fuse.(*Server).loop()
      /home/vagrant/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.1.1-0.20220627082937-d01fda7edf17/fuse/server.go:487 +0x1e4
  github.com/hanwen/go-fuse/v2/fuse.(*Server).Serve()
      /home/vagrant/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.1.1-0.20220627082937-d01fda7edf17/fuse/server.go:409 +0x49
  github.com/superfly/litefs/fuse.(*FileSystem).Mount.func1()
      /home/vagrant/src/superfly/litefs/fuse/fuse.go:80 +0x39

Previous write at 0x00c00011c420 by goroutine 11:
  sync/atomic.AddInt32()
      /usr/local/go/src/runtime/race_amd64.s:279 +0xb
  sync/atomic.AddInt32()
      <autogenerated>:1 +0x1a
  github.com/superfly/litefs/fuse.(*FileSystem).Release.func1()
      /home/vagrant/src/superfly/litefs/fuse/fuse.go:414 +0x39
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:436 +0x32
  github.com/hanwen/go-fuse/v2/fuse.doRelease()
      /home/vagrant/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.1.1-0.20220627082937-d01fda7edf17/fuse/opcode.go:388 +0xa7
  github.com/hanwen/go-fuse/v2/fuse.(*Server).handleRequest()
      /home/vagrant/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.1.1-0.20220627082937-d01fda7edf17/fuse/server.go:514 +0x555
  github.com/hanwen/go-fuse/v2/fuse.(*Server).loop()
      /home/vagrant/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.1.1-0.20220627082937-d01fda7edf17/fuse/server.go:487 +0x1e4
  github.com/hanwen/go-fuse/v2/fuse.(*Server).readRequest.func3()
      /home/vagrant/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.1.1-0.20220627082937-d01fda7edf17/fuse/server.go:354 +0x3e

Goroutine 9 (running) created at:
  github.com/superfly/litefs/fuse.(*FileSystem).Mount()
      /home/vagrant/src/superfly/litefs/fuse/fuse.go:80 +0x1bd
  github.com/superfly/litefs/fuse_test.newOpenFileSystem()
      /home/vagrant/src/superfly/litefs/fuse/fuse_test.go:224 +0x5d
  github.com/superfly/litefs/fuse_test.TestFileSystem_OK.func1()
      /home/vagrant/src/superfly/litefs/fuse/fuse_test.go:29 +0x5d
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x47

Goroutine 11 (running) created at:
  github.com/hanwen/go-fuse/v2/fuse.(*Server).readRequest()
      /home/vagrant/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.1.1-0.20220627082937-d01fda7edf17/fuse/server.go:354 +0x875
  github.com/hanwen/go-fuse/v2/fuse.(*Server).loop()
      /home/vagrant/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.1.1-0.20220627082937-d01fda7edf17/fuse/server.go:465 +0xb8
  github.com/hanwen/go-fuse/v2/fuse.(*Server).Serve()
      /home/vagrant/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.1.1-0.20220627082937-d01fda7edf17/fuse/server.go:409 +0x49
  github.com/superfly/litefs/fuse.(*FileSystem).Mount.func1()
      /home/vagrant/src/superfly/litefs/fuse/fuse.go:80 +0x39
```