### PR TITLE
Prevent WAL mode from being set

### DIFF
--- a/fuse/fuse.go
+++ b/fuse/fuse.go
@@ -1125,7 +1125,7 @@ func toErrno(err error) fuse.Status {
 	} else if err == litefs.ErrReadOnlyReplica {
 		return fuse.EROFS
 	}
-	return fuse.EPERM
+	return fuse.EIO
 }
 
 // errnoError returns the text representation of a FUSE code.

--- a/fuse/fuse_test.go
+++ b/fuse/fuse_test.go
@@ -89,6 +89,19 @@ func TestFileSystem_OK(t *testing.T) {
 	}
 }
 
+// Ensure LiteFS prevents a database from enabling WAL mode on a database.
+func TestFileSystem_PreventWAL(t *testing.T) {
+	fs := newOpenFileSystem(t)
+	dsn := filepath.Join(fs.Path(), "db")
+	db := testingutil.OpenSQLDB(t, dsn)
+
+	// Set the journaling mode.
+	var x string
+	if err := db.QueryRow(`PRAGMA journal_mode = WAL`).Scan(&x); err == nil || err.Error() != `disk I/O error` {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
 func TestFileSystem_Rollback(t *testing.T) {
 	fs := newOpenFileSystem(t)
 	dsn := filepath.Join(fs.Path(), "db")


### PR DESCRIPTION
This pull request blocks page writes that set the read & write file format versions to anything other than the rollback journal mode (`0x01`). This is a temporary fix until WAL support is enabled (#14).

Fixes #15