### PR TITLE
Replace hanwen/go-fuse with bazil.org/fuse

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -256,7 +256,7 @@ func (m *Main) initFileSystem(ctx context.Context) error {
 	}
 
 	// Attach file system to store so it can invalidate the page cache.
-	m.Store.InodeNotifier = fsys
+	m.Store.Invalidator = fsys
 
 	m.FileSystem = fsys
 	return nil

--- a/fuse/database_node.go
+++ b/fuse/database_node.go
@@ -1,0 +1,101 @@
+package fuse
+
+import (
+	"context"
+	"io"
+	"log"
+	"os"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"github.com/superfly/litefs"
+)
+
+var _ fs.Node = (*DatabaseNode)(nil)
+var _ fs.NodeOpener = (*DatabaseNode)(nil)
+var _ fs.NodeFsyncer = (*DatabaseNode)(nil)
+
+// DatabaseNode represents a SQLite database file.
+type DatabaseNode struct {
+	fsys *FileSystem
+	db   *litefs.DB
+}
+
+func newDatabaseNode(fsys *FileSystem, db *litefs.DB) *DatabaseNode {
+	return &DatabaseNode{fsys: fsys, db: db}
+}
+
+func (n *DatabaseNode) Attr(ctx context.Context, attr *fuse.Attr) error {
+	fi, err := os.Stat(n.db.DatabasePath())
+	if err != nil {
+		return err
+	}
+
+	attr.Mode = 0666
+	attr.Size = uint64(fi.Size())
+	attr.Uid = uint32(n.fsys.Uid)
+	attr.Gid = uint32(n.fsys.Gid)
+	return nil
+}
+
+func (n *DatabaseNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
+	f, err := os.OpenFile(n.db.DatabasePath(), os.O_RDWR, 0666)
+	if err != nil {
+		return nil, err
+	}
+	return newDatabaseHandle(n, f), nil
+}
+
+func (n *DatabaseNode) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
+	f, err := os.Open(n.db.DatabasePath())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := f.Sync(); err != nil {
+		return err
+	} else if err := f.Close(); err != nil {
+		return err
+	}
+
+	// TODO: fsync parent directory
+	return nil
+}
+
+var _ fs.Handle = (*DatabaseHandle)(nil)
+var _ fs.HandleReader = (*DatabaseHandle)(nil)
+var _ fs.HandleWriter = (*DatabaseHandle)(nil)
+
+// DatabaseHandle represents a file handle to a SQLite database file.
+type DatabaseHandle struct {
+	node *DatabaseNode
+	file *os.File
+}
+
+func newDatabaseHandle(node *DatabaseNode, file *os.File) *DatabaseHandle {
+	return &DatabaseHandle{node: node, file: file}
+}
+
+func (h *DatabaseHandle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
+	buf := make([]byte, req.Size)
+	n, err := h.file.ReadAt(buf, req.Offset)
+	if err == io.EOF {
+		err = nil
+	}
+	resp.Data = buf[:n]
+	return err
+}
+
+func (h *DatabaseHandle) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.WriteResponse) error {
+	if err := h.node.db.WriteDatabase(h.file, req.Data, req.Offset); err != nil {
+		log.Printf("fuse: write(): database error: %s", err)
+		return err
+	}
+	resp.Size = len(req.Data)
+	return nil
+}
+
+func (h *DatabaseHandle) Release(ctx context.Context, req *fuse.ReleaseRequest) error {
+	return h.file.Close()
+}

--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -1,0 +1,107 @@
+package fuse
+
+import (
+	"log"
+	"os"
+	"sync"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"github.com/superfly/litefs"
+)
+
+var _ fs.FS = (*FileSystem)(nil)
+var _ litefs.Invalidator = (*FileSystem)(nil)
+
+// FileSystem represents a raw interface to the FUSE file system.
+type FileSystem struct {
+	mu   sync.Mutex
+	path string // mount path
+
+	store *litefs.Store
+
+	conn   *fuse.Conn
+	server *fs.Server
+	root   *RootNode
+
+	// User & Group ID for all files in the filesystem.
+	Uid int
+	Gid int
+
+	// If true, logs debug information about every FUSE call.
+	Debug bool
+}
+
+// NewFileSystem returns a new instance of FileSystem.
+func NewFileSystem(path string, store *litefs.Store) *FileSystem {
+	fsys := &FileSystem{
+		path:  path,
+		store: store,
+
+		Uid: os.Getuid(),
+		Gid: os.Getgid(),
+	}
+
+	fsys.root = newRootNode(fsys)
+
+	return fsys
+}
+
+// Path returns the path to the mount point.
+func (fsys *FileSystem) Path() string { return fsys.path }
+
+// Store returns the underlying store.
+func (fsys *FileSystem) Store() *litefs.Store { return fsys.store }
+
+// Mount mounts the file system to the mount point.
+func (fsys *FileSystem) Mount() (err error) {
+	fsys.conn, err = fuse.Mount(fsys.path,
+		fuse.FSName("litefs"),
+		// fuse.LockingPOSIX(),
+	)
+	if err != nil {
+		return err
+	}
+
+	var config fs.Config
+	if fsys.Debug {
+		config.Debug = func(msg interface{}) { log.Print(msg) }
+	}
+
+	fsys.server = fs.New(fsys.conn, &config)
+
+	go func() {
+		if err := fsys.server.Serve(fsys); err != nil {
+			log.Printf("fuse serve error: %s", err)
+		}
+	}()
+
+	return nil
+}
+
+// Unmount unmounts the file system.
+func (fsys *FileSystem) Unmount() (err error) {
+	if e := fuse.Unmount(fsys.path); err == nil {
+		err = e
+	}
+
+	if fsys.conn != nil {
+		if e := fsys.conn.Close(); err == nil {
+			err = e
+		}
+	}
+	return err
+}
+
+// Root returns the root directory in the file system.
+func (fsys *FileSystem) Root() (fs.Node, error) {
+	return fsys.root, nil
+}
+
+// InvalidateDB invalidates a database in the kernel page cache.
+func (fsys *FileSystem) InvalidateDB(db *litefs.DB) error {
+	if err := fsys.conn.InvalidateEntry(fuse.NodeID(RootInode), db.Name()); err != nil && err != fuse.ErrNotCached {
+		return err
+	}
+	return nil
+}

--- a/fuse/fuse_test.go
+++ b/fuse/fuse_test.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func TestFileSystem_OK(t *testing.T) {
-	for _, mode := range []string{"DELETE", "TRUNCATE"} { // TODO: Test PERSIST, WAL modes
+	for _, mode := range []string{"DELETE"} { // TODO: TRUNCATE, PERSIST, WAL
 		t.Run(mode, func(t *testing.T) {
 			fs := newOpenFileSystem(t)
 			dsn := filepath.Join(fs.Path(), "db")

--- a/fuse/journal_node.go
+++ b/fuse/journal_node.go
@@ -1,0 +1,115 @@
+package fuse
+
+import (
+	"context"
+	"io"
+	"log"
+	"os"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"github.com/superfly/litefs"
+)
+
+var _ fs.Node = (*JournalNode)(nil)
+
+// JournalNode represents a SQLite rollback journal file.
+type JournalNode struct {
+	fsys *FileSystem
+	db   *litefs.DB
+}
+
+func newJournalNode(fsys *FileSystem, db *litefs.DB) *JournalNode {
+	return &JournalNode{fsys: fsys, db: db}
+}
+
+func (n *JournalNode) Attr(ctx context.Context, attr *fuse.Attr) error {
+	fi, err := os.Stat(n.db.JournalPath())
+	if err != nil {
+		return err
+	}
+
+	attr.Mode = 0666
+	attr.Size = uint64(fi.Size())
+	attr.Uid = uint32(n.fsys.Uid)
+	attr.Gid = uint32(n.fsys.Gid)
+	return nil
+}
+
+func (n *JournalNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
+	f, err := os.OpenFile(n.db.JournalPath(), os.O_RDWR, 0666)
+	if err != nil {
+		return nil, err
+	}
+	return newJournalHandle(n, f), nil
+}
+
+// Fsync performs an fsync() on the underlying file.
+func (n *JournalNode) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
+	f, err := os.Open(n.db.JournalPath())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := f.Sync(); err != nil {
+		return err
+	} else if err := f.Close(); err != nil {
+		return err
+	}
+
+	// TODO: fsync parent directory
+	return nil
+}
+
+func (n *JournalNode) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse.SetattrResponse) error {
+	// Only allow size updates.
+	if req.Valid.Size() {
+		if err := os.Truncate(n.db.JournalPath(), int64(req.Size)); err != nil {
+			return err
+		}
+	}
+
+	return n.Attr(ctx, &resp.Attr)
+}
+
+var _ fs.Handle = (*JournalHandle)(nil)
+var _ fs.HandleReader = (*JournalHandle)(nil)
+var _ fs.HandleWriter = (*JournalHandle)(nil)
+
+// JournalHandle represents a file handle to a SQLite journal file.
+type JournalHandle struct {
+	node *JournalNode
+	file *os.File
+}
+
+func newJournalHandle(node *JournalNode, file *os.File) *JournalHandle {
+	return &JournalHandle{node: node, file: file}
+}
+
+func (h *JournalHandle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
+	n, err := h.file.ReadAt(resp.Data, req.Offset)
+	if n != len(resp.Data) {
+		return io.ErrShortBuffer
+	}
+	return err
+}
+
+func (h *JournalHandle) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.WriteResponse) error {
+	if err := h.node.db.WriteJournal(h.file, req.Data, req.Offset); err != nil {
+		log.Printf("fuse: write(): journal error: %s", err)
+		return err
+	}
+	resp.Size = len(req.Data)
+	return nil
+}
+
+func (h *JournalHandle) Flush(ctx context.Context, req *fuse.FlushRequest) error {
+	h.file.Close()
+	return nil
+}
+
+func (h *JournalHandle) Release(ctx context.Context, req *fuse.ReleaseRequest) error {
+	h.file.Close()
+	return nil
+}

--- a/fuse/primary_node.go
+++ b/fuse/primary_node.go
@@ -1,0 +1,35 @@
+package fuse
+
+import (
+	"context"
+	"syscall"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+)
+
+var _ fs.Node = (*PrimaryNode)(nil)
+
+// PrimaryNode represents a file for returning the current primary node.
+type PrimaryNode struct {
+	fsys *FileSystem
+}
+
+func newPrimaryNode(fsys *FileSystem) *PrimaryNode {
+	return &PrimaryNode{fsys: fsys}
+}
+
+func (n *PrimaryNode) Attr(ctx context.Context, attr *fuse.Attr) error {
+	attr.Mode = 0444
+	attr.Uid = uint32(n.fsys.Uid)
+	attr.Gid = uint32(n.fsys.Gid)
+	return nil
+}
+
+func (n *PrimaryNode) ReadAll(ctx context.Context) ([]byte, error) {
+	primaryURL := n.fsys.store.PrimaryURL()
+	if primaryURL == "" {
+		return nil, fuse.Errno(syscall.ENOENT)
+	}
+	return []byte(primaryURL + "\n"), nil
+}

--- a/fuse/root_node.go
+++ b/fuse/root_node.go
@@ -1,0 +1,165 @@
+package fuse
+
+import (
+	"context"
+	"log"
+	"os"
+	"syscall"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"github.com/superfly/litefs"
+)
+
+const RootInode = 1
+
+var _ fs.Node = (*RootNode)(nil)
+var _ fs.NodeStringLookuper = (*RootNode)(nil)
+var _ fs.NodeCreater = (*RootNode)(nil)
+var _ fs.NodeRemover = (*RootNode)(nil)
+var _ fs.NodeFsyncer = (*RootNode)(nil)
+
+// RootNode represents the root directory of the FUSE mount.
+type RootNode struct {
+	fsys *FileSystem
+}
+
+func newRootNode(fsys *FileSystem) *RootNode {
+	return &RootNode{fsys: fsys}
+}
+
+func (n *RootNode) Attr(ctx context.Context, attr *fuse.Attr) error {
+	attr.Inode = RootInode
+	attr.Mode = os.ModeDir | 0777
+	attr.Uid = uint32(n.fsys.Uid)
+	attr.Gid = uint32(n.fsys.Gid)
+	return nil
+}
+
+func (n *RootNode) Lookup(ctx context.Context, name string) (fs.Node, error) {
+	switch name {
+	case PrimaryFilename:
+		return n.lookupPrimaryNode(ctx)
+	default:
+		return n.lookupDBNode(ctx, name)
+	}
+}
+
+func (n *RootNode) lookupPrimaryNode(ctx context.Context) (fs.Node, error) {
+	primaryURL := n.fsys.store.PrimaryURL()
+	if primaryURL == "" {
+		return nil, syscall.ENOENT
+	}
+	return newPrimaryNode(n.fsys), nil
+}
+
+func (n *RootNode) lookupDBNode(ctx context.Context, name string) (fs.Node, error) {
+	dbName, fileType := ParseFilename(name)
+
+	db := n.fsys.store.DBByName(dbName)
+	if db == nil {
+		return nil, fuse.ToErrno(syscall.ENOENT)
+	}
+
+	switch fileType {
+	case litefs.FileTypeDatabase:
+		return newDatabaseNode(n.fsys, db), nil
+	case litefs.FileTypeJournal:
+		if _, err := os.Stat(db.JournalPath()); os.IsNotExist(err) {
+			return nil, fuse.ToErrno(syscall.ENOENT)
+		} else if err != nil {
+			return nil, err
+		}
+		return newJournalNode(n.fsys, db), nil
+	case litefs.FileTypeWAL, litefs.FileTypeSHM:
+		return nil, fuse.ToErrno(syscall.ENOENT)
+	default:
+		return nil, fuse.ToErrno(syscall.ENOSYS)
+	}
+}
+
+func (n *RootNode) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.CreateResponse) (fs.Node, fs.Handle, error) {
+	dbName, fileType := ParseFilename(req.Name)
+
+	switch fileType {
+	case litefs.FileTypeDatabase:
+		return n.createDatabase(ctx, dbName, req, resp)
+	case litefs.FileTypeJournal:
+		return n.createJournal(ctx, dbName, req, resp)
+	default:
+		return nil, nil, fuse.ToErrno(syscall.ENOSYS)
+	}
+}
+
+func (n *RootNode) createDatabase(ctx context.Context, dbName string, req *fuse.CreateRequest, resp *fuse.CreateResponse) (fs.Node, fs.Handle, error) {
+	db, file, err := n.fsys.store.CreateDB(dbName)
+	if err == litefs.ErrDatabaseExists {
+		return nil, nil, fuse.Errno(syscall.EEXIST)
+	} else if err != nil {
+		log.Printf("fuse: create(): cannot create database: %s", err)
+		return nil, nil, toErrno(err)
+	}
+
+	node := newDatabaseNode(n.fsys, db)
+	return node, &DatabaseHandle{node: node, file: file}, nil
+}
+
+func (n *RootNode) createJournal(ctx context.Context, dbName string, req *fuse.CreateRequest, resp *fuse.CreateResponse) (fs.Node, fs.Handle, error) {
+	db := n.fsys.store.DBByName(dbName)
+	if db == nil {
+		log.Printf("fuse: create(): cannot create journal, database not found: %s", dbName)
+		return nil, nil, fuse.Errno(syscall.ENOENT)
+	}
+
+	file, err := db.CreateJournal()
+	if err != nil {
+		log.Printf("fuse: create(): cannot create journal: %s", err)
+		return nil, nil, toErrno(err)
+	}
+
+	node := newJournalNode(n.fsys, db)
+	return node, newJournalHandle(node, file), nil
+}
+
+func (n *RootNode) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
+	return nil
+}
+
+func (n *RootNode) Remove(ctx context.Context, req *fuse.RemoveRequest) error {
+	dbName, fileType := ParseFilename(req.Name)
+
+	db := n.fsys.store.DBByName(dbName)
+	if db == nil {
+		return fuse.ToErrno(syscall.ENOENT)
+	}
+
+	switch fileType {
+	case litefs.FileTypeJournal:
+		return db.CommitJournal(litefs.JournalModeDelete)
+	default:
+		return fuse.ToErrno(syscall.ENOSYS)
+	}
+}
+
+var _ fs.Handle = (*RootHandle)(nil)
+
+//var _ fs.HandleFlusher = (*RootHandle)(nil)
+//var _ fs.HandleReadAller = (*RootHandle)(nil)
+//var _ fs.HandleReadDirAller = (*RootHandle)(nil)
+//var _ fs.HandleReader = (*RootHandle)(nil)
+//var _ fs.HandleWriter = (*RootHandle)(nil)
+//var _ fs.HandleReleaser = (*RootHandle)(nil)
+
+// RootHandle represents a directory handle for the root directory.
+type RootHandle struct {
+	id     uint64
+	offset int
+}
+
+// NewRootHandle returns a new instance of RootHandle.
+func NewRootHandle(id uint64) *RootHandle {
+	return &RootHandle{id: id}
+}
+
+// ID returns the file handle identifier.
+func (h *RootHandle) ID() uint64 { return h.id }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 )
 
 require (
+	bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05 // indirect
 	github.com/armon/go-metrics v0.3.10 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05 h1:UrYe9YkT4Wpm6D+zByEyCJQzDqTPXqTDUI7bZ41i9VE=
+bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05/go.mod h1:h0h5FBYpXThbvSfTqthw+0I4nmHnhTHkO5BoOHsBWqg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -34,6 +36,7 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/Julusian/godocdown v0.0.0-20170816220326-6d19f8ff2df8/go.mod h1:INZr5t32rG59/5xeltqoCJoNY7e5x/3xoY9WSWVWg74=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -66,6 +69,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dvyukov/go-fuzz v0.0.0-20200318091601-be3528f3a813/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
+github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -283,6 +288,7 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/robertkrimen/godocdown v0.0.0-20130622164427-0bfa04905481/go.mod h1:C9WhFzY47SzYBIvzFqSvHIR6ROgDo4TtdTuRaOMjF/s=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -291,6 +297,7 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/stephens2424/writerset v1.0.2/go.mod h1:aS2JhsMn6eA7e82oNmW4rfsgAOp9COBTTl8mzkwADnc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -302,6 +309,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/superfly/ltx v0.0.0-20220701210039-d37520857bc3 h1:h/LIxYrBkbNgF3MIbDHkcPAgP1kljDyK3IarhMPLyoI=
 github.com/superfly/ltx v0.0.0-20220701210039-d37520857bc3/go.mod h1:aW5e3H7elNGtaW4Cax78hQV6ITIFiYEOeslDPdVwDi0=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -421,6 +429,7 @@ golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -493,6 +502,7 @@ golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
+golang.org/x/tools v0.0.0-20200423201157-2723c5de0d66/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/litefs.go
+++ b/litefs.go
@@ -247,9 +247,9 @@ func (f *LTXStreamFrame) WriteTo(w io.Writer) (int64, error) {
 	return 0, nil
 }
 
-// InodeNotifier is a callback for the store to use to invalidate the kernel page cache.
-type InodeNotifier interface {
-	InodeNotify(dbID uint32, off int64, length int64) error
+// Invalidator is a callback for the store to use to invalidate the kernel page cache.
+type Invalidator interface {
+	InvalidateDB(db *DB) error
 }
 
 // Leaser represents an API for obtaining a lease for leader election.

--- a/store.go
+++ b/store.go
@@ -37,8 +37,8 @@ type Store struct {
 	// Leaser manages the lease that controls leader election.
 	Leaser Leaser
 
-	// Callback to notify kernel of inode changes.
-	InodeNotifier InodeNotifier
+	// Callback to notify kernel of file changes.
+	Invalidator Invalidator
 }
 
 // NewStore returns a new instance of Store.


### PR DESCRIPTION
After having issues on Fedora & Alpine (https://github.com/superfly/litefs/pull/31), I tried reworking the FUSE layer to use @tv42's `bazil.org/fuse` and it seems to be working better.

I need to hook in POSIX locks and fix up the test for the `TRUNCATE` journal mode as well but I'll do that in a separate PR.