### PR TITLE
Fix FUSE file invalidation

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,7 +4,7 @@ on: ["push"]
 jobs:
   build:
     name: Build
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     env:
       GOPRIVATE: "github.com/superfly/*"
     steps:
@@ -19,7 +19,7 @@ jobs:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: apt install
-        run: sudo apt install -y fuse3 libfuse-dev libsqlite3-dev
+        run: sudo apt install -y fuse libfuse-dev libsqlite3-dev
 
       - name: check fuse version
         run: fusermount -V
@@ -37,4 +37,4 @@ jobs:
         run: go test -v .
 
       - name: Run FUSE tests
-        run: go test -v -p 1 ./fuse
+        run: go test -v -p 1 ./fuse -debug

--- a/cmd/litefs/main_test.go
+++ b/cmd/litefs/main_test.go
@@ -73,6 +73,19 @@ func TestMultiNode_Simple(t *testing.T) {
 	} else if got, want := x, 100; got != want {
 		t.Fatalf("x=%d, want %d", got, want)
 	}
+
+	// Write another value.
+	if _, err := db0.Exec(`INSERT INTO t VALUES (200)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure it invalidates the page on the secondary.
+	waitForSync(t, 1, m0, m1)
+	if err := db1.QueryRow(`SELECT COUNT(*) FROM t`).Scan(&x); err != nil {
+		t.Fatal(err)
+	} else if got, want := x, 2; got != want {
+		t.Fatalf("count=%d, want %d", got, want)
+	}
 }
 
 func TestMultiNode_ForcedReelection(t *testing.T) {

--- a/db.go
+++ b/db.go
@@ -464,7 +464,7 @@ func (db *DB) TryApplyLTX(path string) error {
 
 		// Invalidate page cache.
 		if invalidator := db.store.Invalidator; invalidator != nil {
-			if err := invalidator.InvalidateDB(db); err != nil {
+			if err := invalidator.InvalidateDB(db, offset, int64(len(pageBuf))); err != nil {
 				return fmt.Errorf("invalidate db: %w", err)
 			}
 		}

--- a/fuse/database_node.go
+++ b/fuse/database_node.go
@@ -16,6 +16,7 @@ import (
 var _ fs.Node = (*DatabaseNode)(nil)
 var _ fs.NodeOpener = (*DatabaseNode)(nil)
 var _ fs.NodeFsyncer = (*DatabaseNode)(nil)
+var _ fs.NodeForgetter = (*DatabaseNode)(nil)
 
 // DatabaseNode represents a SQLite database file.
 type DatabaseNode struct {
@@ -64,6 +65,8 @@ func (n *DatabaseNode) Fsync(ctx context.Context, req *fuse.FsyncRequest) error 
 	// TODO: fsync parent directory
 	return nil
 }
+
+func (n *DatabaseNode) Forget() { n.fsys.root.ForgetNode(n) }
 
 var _ fs.Handle = (*DatabaseHandle)(nil)
 var _ fs.HandleReader = (*DatabaseHandle)(nil)

--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -99,8 +99,13 @@ func (fsys *FileSystem) Root() (fs.Node, error) {
 }
 
 // InvalidateDB invalidates a database in the kernel page cache.
-func (fsys *FileSystem) InvalidateDB(db *litefs.DB) error {
-	if err := fsys.conn.InvalidateEntry(fuse.NodeID(RootInode), db.Name()); err != nil && err != fuse.ErrNotCached {
+func (fsys *FileSystem) InvalidateDB(db *litefs.DB, offset, size int64) error {
+	node := fsys.root.Node(db.Name())
+	if node == nil {
+		return nil
+	}
+
+	if err := fsys.server.InvalidateNodeDataRange(node, offset, size); err != nil && err != fuse.ErrNotCached {
 		return err
 	}
 	return nil

--- a/fuse/journal_node.go
+++ b/fuse/journal_node.go
@@ -12,6 +12,7 @@ import (
 )
 
 var _ fs.Node = (*JournalNode)(nil)
+var _ fs.NodeForgetter = (*JournalNode)(nil)
 
 // JournalNode represents a SQLite rollback journal file.
 type JournalNode struct {
@@ -72,6 +73,8 @@ func (n *JournalNode) Setattr(ctx context.Context, req *fuse.SetattrRequest, res
 
 	return n.Attr(ctx, &resp.Attr)
 }
+
+func (n *JournalNode) Forget() { n.fsys.root.ForgetNode(n) }
 
 var _ fs.Handle = (*JournalHandle)(nil)
 var _ fs.HandleReader = (*JournalHandle)(nil)

--- a/fuse/primary_node.go
+++ b/fuse/primary_node.go
@@ -9,6 +9,7 @@ import (
 )
 
 var _ fs.Node = (*PrimaryNode)(nil)
+var _ fs.NodeForgetter = (*PrimaryNode)(nil)
 
 // PrimaryNode represents a file for returning the current primary node.
 type PrimaryNode struct {
@@ -33,3 +34,5 @@ func (n *PrimaryNode) ReadAll(ctx context.Context) ([]byte, error) {
 	}
 	return []byte(primaryURL + "\n"), nil
 }
+
+func (n *PrimaryNode) Forget() { n.fsys.root.ForgetNode(n) }

--- a/litefs.go
+++ b/litefs.go
@@ -249,7 +249,7 @@ func (f *LTXStreamFrame) WriteTo(w io.Writer) (int64, error) {
 
 // Invalidator is a callback for the store to use to invalidate the kernel page cache.
 type Invalidator interface {
-	InvalidateDB(db *DB) error
+	InvalidateDB(db *DB, offset, size int64) error
 }
 
 // Leaser represents an API for obtaining a lease for leader election.


### PR DESCRIPTION
This PR fixes the OS page cache invalidation on replica nodes by using `fs.Server.InvalidateNodeDataRange()` instead of `fuse.Conn.InvalidateEntry()`.