### PR TITLE
Implement candidacy

### DIFF
--- a/cmd/litefs/etc/litefs.yml
+++ b/cmd/litefs/etc/litefs.yml
@@ -6,6 +6,9 @@
 # same name but is prefixed with a dot (".")
 mount-dir: "/path/to/mnt"
 
+# The candidate flag specifies whether the node can become the primary.
+candidate: true
+
 # The debug flag enables debug logging of all FUSE API calls. This will produce
 # a lot of logging and should not be on for general use.
 debug: false

--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -232,7 +232,7 @@ func (m *Main) initStore(ctx context.Context) error {
 	}
 	dir, file := filepath.Split(mountDir)
 
-	m.Store = litefs.NewStore(filepath.Join(dir, "."+file))
+	m.Store = litefs.NewStore(filepath.Join(dir, "."+file), m.Config.Candidate)
 	m.Store.Client = http.NewClient()
 	return nil
 }
@@ -304,9 +304,10 @@ func (m *Main) execCmd(ctx context.Context) error {
 
 // Config represents a configuration for the binary process.
 type Config struct {
-	MountDir string `yaml:"mount-dir"`
-	Exec     string `yaml:"exec"`
-	Debug    bool   `yaml:"debug"`
+	MountDir  string `yaml:"mount-dir"`
+	Exec      string `yaml:"exec"`
+	Debug     bool   `yaml:"debug"`
+	Candidate bool   `yaml:"candidate"`
 
 	HTTP struct {
 		Addr string `yaml:"addr"`
@@ -324,6 +325,7 @@ type Config struct {
 // NewConfig returns a new instance of Config with defaults set.
 func NewConfig() Config {
 	var config Config
+	config.Candidate = true
 	config.HTTP.Addr = http.DefaultAddr
 	config.Consul.Key = consul.DefaultKey
 	config.Consul.TTL = consul.DefaultTTL

--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -230,7 +230,7 @@ func newFileSystem(tb testing.TB) *fuse.FileSystem {
 	tb.Helper()
 
 	path := tb.TempDir()
-	store := litefs.NewStore(filepath.Join(path, ".mnt"))
+	store := litefs.NewStore(filepath.Join(path, ".mnt"), true)
 	if err := store.Open(); err != nil {
 		tb.Fatalf("cannot open store: %s", err)
 	}

--- a/store_test.go
+++ b/store_test.go
@@ -92,7 +92,7 @@ func TestStore_Open(t *testing.T) {
 // newStore returns a new instance of a Store on a temporary directory.
 // This store will automatically close when the test ends.
 func newStore(tb testing.TB) *litefs.Store {
-	store := litefs.NewStore(tb.TempDir())
+	store := litefs.NewStore(tb.TempDir(), true)
 	tb.Cleanup(func() {
 		if err := store.Close(); err != nil {
 			tb.Fatalf("cannot close store: %s", err)


### PR DESCRIPTION
This pull request adds a `candidate` flag to the config which tells the node whether it can become the primary or not. It defaults to `true`.

Original PR: https://github.com/jwhear/litefs/pull/1

Fixes #16 