### PR TITLE
Implement static lease

### DIFF
--- a/cmd/litefs/etc/litefs.yml
+++ b/cmd/litefs/etc/litefs.yml
@@ -43,3 +43,12 @@ consul:
   # This buffer is intended to prevent overlap in leadership due to clock skew
   # or in-flight API calls.
   lock-delay: "5s"
+
+# Static leadership can be used instead of Consul if only one node should ever
+# be the primary. Only one node in the cluster can be marked as the "primary".
+static:
+  # Specifies that the current node is the primary.
+  primary: true
+
+  # The URL of the primary node.
+  primary-url: "http://localhost:20202"

--- a/http/server.go
+++ b/http/server.go
@@ -72,11 +72,15 @@ func (s *Server) Serve() {
 
 func (s *Server) Close() (err error) {
 	if s.ln != nil {
-		if e := s.ln.Close(); e != nil && err == nil {
+		if e := s.ln.Close(); err == nil {
 			err = e
 		}
 	}
-
+	if s.httpServer != nil {
+		if e := s.httpServer.Close(); err == nil {
+			err = e
+		}
+	}
 	s.cancel()
 	if e := s.g.Wait(); e != nil && err == nil {
 		err = e

--- a/lease.go
+++ b/lease.go
@@ -1,0 +1,103 @@
+package litefs
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+// Leaser represents an API for obtaining a lease for leader election.
+type Leaser interface {
+	io.Closer
+
+	AdvertiseURL() string
+
+	// Acquire attempts to acquire the lease to become the primary.
+	Acquire(ctx context.Context) (Lease, error)
+
+	// PrimaryURL attempts to read the current primary URL.
+	// Returns ErrNoPrimary if no primary has the lease.
+	PrimaryURL(ctx context.Context) (string, error)
+}
+
+// Lease represents an acquired lease from a Leaser.
+type Lease interface {
+	RenewedAt() time.Time
+	TTL() time.Duration
+
+	// Renew attempts to reset the TTL on the lease.
+	// Returns ErrLeaseExpired if the lease has expired or was deleted.
+	Renew(ctx context.Context) error
+
+	// Close attempts to remove the lease from the server.
+	Close() error
+}
+
+// StaticLeaser always returns a lease to a static primary.
+type StaticLeaser struct {
+	isPrimary  bool
+	primaryURL string
+}
+
+// NewStaticLeaser returns a new instance of StaticLeaser.
+func NewStaticLeaser(isPrimary bool, primaryURL string) *StaticLeaser {
+	return &StaticLeaser{
+		isPrimary:  isPrimary,
+		primaryURL: primaryURL,
+	}
+}
+
+// Close is a no-op.
+func (l *StaticLeaser) Close() (err error) { return nil }
+
+// AdvertiseURL returns the primary URL if this is the primary.
+// Otherwise returns blank.
+func (l *StaticLeaser) AdvertiseURL() string {
+	if l.isPrimary {
+		return l.primaryURL
+	}
+	return ""
+}
+
+// Acquire returns a lease if this node is the static primary.
+// Otherwise returns ErrPrimaryExists.
+func (l *StaticLeaser) Acquire(ctx context.Context) (Lease, error) {
+	if !l.isPrimary {
+		return nil, ErrPrimaryExists
+	}
+	return &StaticLease{leaser: l}, nil
+}
+
+// PrimaryURL returns the primary's URL for replicas.
+// Returns ErrNoPrimary if the node is the primary.
+func (l *StaticLeaser) PrimaryURL(ctx context.Context) (string, error) {
+	if l.isPrimary {
+		return "", ErrNoPrimary
+	}
+	return l.primaryURL, nil
+}
+
+// IsPrimary returns true if the current node is the primary.
+func (l *StaticLeaser) IsPrimary() bool {
+	return l.isPrimary
+}
+
+var _ Lease = (*StaticLease)(nil)
+
+// StaticLease represents a lease for a fixed primary.
+type StaticLease struct {
+	leaser *StaticLeaser
+}
+
+// RenewedAt returns the Unix epoch in UTC.
+func (l *StaticLease) RenewedAt() time.Time { return time.Unix(0, 0).UTC() }
+
+// TTL returns the duration until the lease expires which is a time well into the future.
+func (l *StaticLease) TTL() time.Duration { return staticLeaseExpiresAt.Sub(l.RenewedAt()) }
+
+// Renew is a no-op.
+func (l *StaticLease) Renew(ctx context.Context) error { return nil }
+
+func (l *StaticLease) Close() error { return nil }
+
+var staticLeaseExpiresAt = time.Date(3000, time.January, 1, 0, 0, 0, 0, time.UTC)

--- a/lease_test.go
+++ b/lease_test.go
@@ -1,0 +1,73 @@
+package litefs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/superfly/litefs"
+)
+
+func TestStaticLeaser(t *testing.T) {
+	t.Run("Primary", func(t *testing.T) {
+		l := litefs.NewStaticLeaser(true, "http://localhost:20202")
+		if got, want := l.AdvertiseURL(), "http://localhost:20202"; got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+
+		if primaryURL, err := l.PrimaryURL(context.Background()); err != litefs.ErrNoPrimary {
+			t.Fatal(err)
+		} else if got, want := primaryURL, ""; got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+
+		if lease, err := l.Acquire(context.Background()); err != nil {
+			t.Fatal(err)
+		} else if lease == nil {
+			t.Fatal("expected lease")
+		}
+
+		if err := l.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("Replica", func(t *testing.T) {
+		l := litefs.NewStaticLeaser(false, "http://localhost:20202")
+		if got, want := l.AdvertiseURL(), ""; got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+
+		if primaryURL, err := l.PrimaryURL(context.Background()); err != nil {
+			t.Fatal(err)
+		} else if got, want := primaryURL, "http://localhost:20202"; got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+
+		if lease, err := l.Acquire(context.Background()); err != litefs.ErrPrimaryExists {
+			t.Fatalf("unexpected error: %v", err)
+		} else if lease != nil {
+			t.Fatal("expected no lease")
+		}
+	})
+}
+
+func TestStaticLease(t *testing.T) {
+	leaser := litefs.NewStaticLeaser(true, "http://localhost:20202")
+	lease, err := leaser.Acquire(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := lease.RenewedAt().String(), `1970-01-01 00:00:00 +0000 UTC`; got != want {
+		t.Fatalf("RenewedAt()=%q, want %q", got, want)
+	}
+	if lease.TTL() <= 0 {
+		t.Fatal("expected TTL")
+	}
+
+	if err := lease.Renew(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/litefs.go
+++ b/litefs.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"time"
 )
 
 // LiteFS errors
@@ -250,33 +249,6 @@ func (f *LTXStreamFrame) WriteTo(w io.Writer) (int64, error) {
 // Invalidator is a callback for the store to use to invalidate the kernel page cache.
 type Invalidator interface {
 	InvalidateDB(db *DB, offset, size int64) error
-}
-
-// Leaser represents an API for obtaining a lease for leader election.
-type Leaser interface {
-	io.Closer
-
-	AdvertiseURL() string
-
-	// Acquire attempts to acquire the lease to become the primary.
-	Acquire(ctx context.Context) (Lease, error)
-
-	// PrimaryURL attempts to read the current primary URL.
-	// Returns ErrNoPrimary if no primary has the lease.
-	PrimaryURL(ctx context.Context) (string, error)
-}
-
-// Lease represents an acquired lease from a Leaser.
-type Lease interface {
-	RenewedAt() time.Time
-	TTL() time.Duration
-
-	// Renew attempts to reset the TTL on the lease.
-	// Returns ErrLeaseExpired if the lease has expired or was deleted.
-	Renew(ctx context.Context) error
-
-	// Close attempts to remove the lease from the server.
-	Close() error
 }
 
 func assert(condition bool, msg string) {

--- a/store.go
+++ b/store.go
@@ -340,8 +340,8 @@ func (s *Store) monitor(ctx context.Context) error {
 		log.Printf("existing primary found (%s), connecting as replica", primaryURL)
 		if err := s.monitorAsReplica(ctx, primaryURL); err != nil {
 			log.Printf("replica disconected, retrying: %s", err)
-			time.Sleep(1 * time.Second)
 		}
+		time.Sleep(1 * time.Second)
 	}
 }
 
@@ -448,7 +448,7 @@ func (s *Store) monitorAsReplica(ctx context.Context, primaryURL string) error {
 	posMap := s.PosMap()
 	st, err := s.Client.Stream(ctx, primaryURL, posMap)
 	if err != nil {
-		return fmt.Errorf("connect to primary: %s", err)
+		return fmt.Errorf("connect to primary: %s ('%s')", err, primaryURL)
 	}
 
 	for {


### PR DESCRIPTION
This adds support for a fixed primary node so that Consul does not need to be used. It will not support handoff of the primary so the cluster will be read-only when the primary stops.

Original PR: https://github.com/jwhear/litefs/pull/2

Fixes #37 

## Usage

Specify the `static` block in your configuration instead of `consul`. You cannot specify both blocks.

#### Primary node

```yml
static:
  primary: true
  primary-url: "http://myhost:20202"
```

#### Replica nodes

```yml
static:
  primary: false
  primary-url: "http://myhost:20202"
```
