### PR TITLE
Return ENOSYS for xattr requests

### DIFF
--- a/fuse/database_node.go
+++ b/fuse/database_node.go
@@ -17,6 +17,10 @@ var _ fs.Node = (*DatabaseNode)(nil)
 var _ fs.NodeOpener = (*DatabaseNode)(nil)
 var _ fs.NodeFsyncer = (*DatabaseNode)(nil)
 var _ fs.NodeForgetter = (*DatabaseNode)(nil)
+var _ fs.NodeListxattrer = (*DatabaseNode)(nil)
+var _ fs.NodeGetxattrer = (*DatabaseNode)(nil)
+var _ fs.NodeSetxattrer = (*DatabaseNode)(nil)
+var _ fs.NodeRemovexattrer = (*DatabaseNode)(nil)
 
 // DatabaseNode represents a SQLite database file.
 type DatabaseNode struct {
@@ -67,6 +71,26 @@ func (n *DatabaseNode) Fsync(ctx context.Context, req *fuse.FsyncRequest) error 
 }
 
 func (n *DatabaseNode) Forget() { n.fsys.root.ForgetNode(n) }
+
+// ENOSYS is a special return code for xattr requests that will be treated as a permanent failure for any such
+// requests in the future without being sent to the filesystem.
+// Source: https://github.com/libfuse/libfuse/blob/0b6d97cf5938f6b4885e487c3bd7b02144b1ea56/include/fuse_lowlevel.h#L811
+
+func (n *DatabaseNode) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *DatabaseNode) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *DatabaseNode) Setxattr(ctx context.Context, req *fuse.SetxattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *DatabaseNode) Removexattr(ctx context.Context, req *fuse.RemovexattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
 
 var _ fs.Handle = (*DatabaseHandle)(nil)
 var _ fs.HandleReader = (*DatabaseHandle)(nil)

--- a/fuse/journal_node.go
+++ b/fuse/journal_node.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"syscall"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
@@ -13,6 +14,10 @@ import (
 
 var _ fs.Node = (*JournalNode)(nil)
 var _ fs.NodeForgetter = (*JournalNode)(nil)
+var _ fs.NodeListxattrer = (*JournalNode)(nil)
+var _ fs.NodeGetxattrer = (*JournalNode)(nil)
+var _ fs.NodeSetxattrer = (*JournalNode)(nil)
+var _ fs.NodeRemovexattrer = (*JournalNode)(nil)
 
 // JournalNode represents a SQLite rollback journal file.
 type JournalNode struct {
@@ -75,6 +80,26 @@ func (n *JournalNode) Setattr(ctx context.Context, req *fuse.SetattrRequest, res
 }
 
 func (n *JournalNode) Forget() { n.fsys.root.ForgetNode(n) }
+
+// ENOSYS is a special return code for xattr requests that will be treated as a permanent failure for any such
+// requests in the future without being sent to the filesystem.
+// Source: https://github.com/libfuse/libfuse/blob/0b6d97cf5938f6b4885e487c3bd7b02144b1ea56/include/fuse_lowlevel.h#L811
+
+func (n *JournalNode) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *JournalNode) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *JournalNode) Setxattr(ctx context.Context, req *fuse.SetxattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *JournalNode) Removexattr(ctx context.Context, req *fuse.RemovexattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
 
 var _ fs.Handle = (*JournalHandle)(nil)
 var _ fs.HandleReader = (*JournalHandle)(nil)

--- a/fuse/primary_node.go
+++ b/fuse/primary_node.go
@@ -13,6 +13,10 @@ const PrimaryFilename = ".primary"
 
 var _ fs.Node = (*PrimaryNode)(nil)
 var _ fs.NodeForgetter = (*PrimaryNode)(nil)
+var _ fs.NodeListxattrer = (*PrimaryNode)(nil)
+var _ fs.NodeGetxattrer = (*PrimaryNode)(nil)
+var _ fs.NodeSetxattrer = (*PrimaryNode)(nil)
+var _ fs.NodeRemovexattrer = (*PrimaryNode)(nil)
 
 // PrimaryNode represents a file for returning the current primary node.
 type PrimaryNode struct {
@@ -39,3 +43,23 @@ func (n *PrimaryNode) ReadAll(ctx context.Context) ([]byte, error) {
 }
 
 func (n *PrimaryNode) Forget() { n.fsys.root.ForgetNode(n) }
+
+// ENOSYS is a special return code for xattr requests that will be treated as a permanent failure for any such
+// requests in the future without being sent to the filesystem.
+// Source: https://github.com/libfuse/libfuse/blob/0b6d97cf5938f6b4885e487c3bd7b02144b1ea56/include/fuse_lowlevel.h#L811
+
+func (n *PrimaryNode) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *PrimaryNode) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *PrimaryNode) Setxattr(ctx context.Context, req *fuse.SetxattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *PrimaryNode) Removexattr(ctx context.Context, req *fuse.RemovexattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}

--- a/fuse/root_node.go
+++ b/fuse/root_node.go
@@ -21,6 +21,10 @@ var _ fs.NodeOpener = (*RootNode)(nil)
 var _ fs.NodeCreater = (*RootNode)(nil)
 var _ fs.NodeRemover = (*RootNode)(nil)
 var _ fs.NodeFsyncer = (*RootNode)(nil)
+var _ fs.NodeListxattrer = (*RootNode)(nil)
+var _ fs.NodeGetxattrer = (*RootNode)(nil)
+var _ fs.NodeSetxattrer = (*RootNode)(nil)
+var _ fs.NodeRemovexattrer = (*RootNode)(nil)
 
 // RootNode represents the root directory of the FUSE mount.
 type RootNode struct {
@@ -207,6 +211,26 @@ func (n *RootNode) ForgetNode(node fs.Node) {
 			delete(n.nodes, k)
 		}
 	}
+}
+
+// ENOSYS is a special return code for xattr requests that will be treated as a permanent failure for any such
+// requests in the future without being sent to the filesystem.
+// Source: https://github.com/libfuse/libfuse/blob/0b6d97cf5938f6b4885e487c3bd7b02144b1ea56/include/fuse_lowlevel.h#L811
+
+func (n *RootNode) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *RootNode) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *RootNode) Setxattr(ctx context.Context, req *fuse.SetxattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *RootNode) Removexattr(ctx context.Context, req *fuse.RemovexattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
 }
 
 var _ fs.Handle = (*RootHandle)(nil)


### PR DESCRIPTION
Return ENOSYS for xattr requests so that they are permanently failed and no longer sent to the filesystem.

Relevant sources:

https://github.com/bazil/fuse/issues/254
https://github.com/libfuse/libfuse/blob/0b6d97cf5938f6b4885e487c3bd7b02144b1ea56/include/fuse_lowlevel.h#L811