### PR TITLE
Implement statfs() callback

### DIFF
--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -1,9 +1,11 @@
 package fuse
 
 import (
+	"context"
 	"log"
 	"os"
 	"sync"
+	"syscall"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
@@ -11,6 +13,7 @@ import (
 )
 
 var _ fs.FS = (*FileSystem)(nil)
+var _ fs.FSStatfser = (*FileSystem)(nil)
 var _ litefs.Invalidator = (*FileSystem)(nil)
 
 // FileSystem represents a raw interface to the FUSE file system.
@@ -96,6 +99,27 @@ func (fsys *FileSystem) Unmount() (err error) {
 // Root returns the root directory in the file system.
 func (fsys *FileSystem) Root() (fs.Node, error) {
 	return fsys.root, nil
+}
+
+// Statfs is a passthrough to the underlying file system.
+func (fsys *FileSystem) Statfs(ctx context.Context, req *fuse.StatfsRequest, resp *fuse.StatfsResponse) error {
+	// Obtain statfs() call from underlying store path.
+	var statfs syscall.Statfs_t
+	if err := syscall.Statfs(fsys.store.Path(), &statfs); err != nil {
+		return err
+	}
+
+	// Copy stats over from the underlying file system to the response.
+	resp.Blocks = statfs.Blocks
+	resp.Bfree = statfs.Bfree
+	resp.Bavail = statfs.Bavail
+	resp.Files = statfs.Files
+	resp.Ffree = statfs.Ffree
+	resp.Bsize = uint32(statfs.Bsize)
+	resp.Namelen = uint32(statfs.Namelen)
+	resp.Frsize = uint32(statfs.Frsize)
+
+	return nil
 }
 
 // InvalidateDB invalidates a database in the kernel page cache.

--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -223,6 +224,15 @@ func TestFileSystem_ReadDir(t *testing.T) {
 		t.Fatal(err)
 	} else if got, want := string(buf), "db0\ndb1\n"; got != want {
 		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+// Ensures the statfs() executes and does not panic.
+func TestFileSystem_Statfs(t *testing.T) {
+	fs := newOpenFileSystem(t)
+	var statfs syscall.Statfs_t
+	if err := syscall.Statfs(fs.Path(), &statfs); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This pull request implements a FUSE callback for `statfs(2)`. The call is simply a passthrough to the underlying file system that the `litefs.Store` is attached to.

Fixes #10 