### PR TITLE
Expose DB position via FUSE

### DIFF
--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -134,3 +134,16 @@ func (fsys *FileSystem) InvalidateDB(db *litefs.DB, offset, size int64) error {
 	}
 	return nil
 }
+
+// InvalidatePos invalidates the position file in the kernel page cache.
+func (fsys *FileSystem) InvalidatePos(db *litefs.DB) error {
+	node := fsys.root.Node(db.Name() + "-pos")
+	if node == nil {
+		return nil
+	}
+
+	if err := fsys.server.InvalidateNodeData(node); err != nil && err != fuse.ErrNotCached {
+		return err
+	}
+	return nil
+}

--- a/fuse/fuse.go
+++ b/fuse/fuse.go
@@ -21,6 +21,8 @@ func FileTypeFilename(t litefs.FileType) string {
 		return "wal"
 	case litefs.FileTypeSHM:
 		return "shm"
+	case litefs.FileTypePos:
+		return "pos"
 	default:
 		panic(fmt.Sprintf("FileTypeFilename(): invalid file type: %d", t))
 	}
@@ -34,6 +36,8 @@ func ParseFilename(name string) (dbName string, fileType litefs.FileType) {
 		return strings.TrimSuffix(name, "-wal"), litefs.FileTypeWAL
 	} else if strings.HasSuffix(name, "-shm") {
 		return strings.TrimSuffix(name, "-shm"), litefs.FileTypeSHM
+	} else if strings.HasSuffix(name, "-pos") {
+		return strings.TrimSuffix(name, "-pos"), litefs.FileTypePos
 	}
 	return name, litefs.FileTypeDatabase
 }

--- a/fuse/pos_node.go
+++ b/fuse/pos_node.go
@@ -1,0 +1,85 @@
+package fuse
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"syscall"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"github.com/superfly/litefs"
+)
+
+// PosFileSize is the size, in bytes, of the "-pos" file.
+const PosFileSize = 33
+
+var _ fs.Node = (*PosNode)(nil)
+var _ fs.NodeOpener = (*PosNode)(nil)
+var _ fs.NodeForgetter = (*PosNode)(nil)
+var _ fs.NodeListxattrer = (*PosNode)(nil)
+var _ fs.NodeGetxattrer = (*PosNode)(nil)
+var _ fs.NodeSetxattrer = (*PosNode)(nil)
+var _ fs.NodeRemovexattrer = (*PosNode)(nil)
+
+// PosNode represents a file that returns the current position of the database.
+type PosNode struct {
+	fsys *FileSystem
+	db   *litefs.DB
+}
+
+func newPosNode(fsys *FileSystem, db *litefs.DB) *PosNode {
+	return &PosNode{fsys: fsys, db: db}
+}
+
+func (n *PosNode) Attr(ctx context.Context, attr *fuse.Attr) error {
+	attr.Mode = 0666
+	attr.Size = uint64(PosFileSize)
+	attr.Uid = uint32(n.fsys.Uid)
+	attr.Gid = uint32(n.fsys.Gid)
+	return nil
+}
+
+func (n *PosNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
+	return n, nil
+}
+
+func (n *PosNode) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
+	pos := n.db.Pos()
+
+	data := fmt.Sprintf("%016x/%016x", pos.TXID, pos.PostApplyChecksum)
+	if req.Offset >= int64(len(data)) {
+		return io.EOF
+	}
+
+	// Size buffer to offset/size.
+	data = data[req.Offset:]
+	if len(data) > req.Size {
+		data = data[:req.Size]
+	}
+	resp.Data = []byte(data)
+
+	return nil
+}
+
+func (n *PosNode) Forget() { n.fsys.root.ForgetNode(n) }
+
+// ENOSYS is a special return code for xattr requests that will be treated as a permanent failure for any such
+// requests in the future without being sent to the filesystem.
+// Source: https://github.com/libfuse/libfuse/blob/0b6d97cf5938f6b4885e487c3bd7b02144b1ea56/include/fuse_lowlevel.h#L811
+
+func (n *PosNode) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *PosNode) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *PosNode) Setxattr(ctx context.Context, req *fuse.SetxattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *PosNode) Removexattr(ctx context.Context, req *fuse.RemovexattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}

--- a/fuse/root_node.go
+++ b/fuse/root_node.go
@@ -112,6 +112,8 @@ func (n *RootNode) lookupDBNode(ctx context.Context, name string) (fs.Node, erro
 		return newJournalNode(n.fsys, db), nil
 	case litefs.FileTypeWAL, litefs.FileTypeSHM:
 		return nil, fuse.ToErrno(syscall.ENOENT)
+	case litefs.FileTypePos:
+		return newPosNode(n.fsys, db), nil
 	default:
 		return nil, fuse.ToErrno(syscall.ENOSYS)
 	}
@@ -184,9 +186,6 @@ func (n *RootNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.O
 
 // Remove deletes the file from disk. This is only supported on the journal file currently.
 func (n *RootNode) Remove(ctx context.Context, req *fuse.RemoveRequest) (err error) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
 	dbName, fileType := ParseFilename(req.Name)
 
 	db := n.fsys.store.DBByName(dbName)

--- a/litefs.go
+++ b/litefs.go
@@ -67,19 +67,20 @@ const (
 // FileType represents a type of SQLite file.
 type FileType int
 
-// SQLite file types.
+// Database file types.
 const (
 	FileTypeNone = FileType(iota)
 	FileTypeDatabase
 	FileTypeJournal
 	FileTypeWAL
 	FileTypeSHM
+	FileTypePos
 )
 
 // IsValid returns true if t is a valid file type.
 func (t FileType) IsValid() bool {
 	switch t {
-	case FileTypeDatabase, FileTypeJournal, FileTypeWAL, FileTypeSHM:
+	case FileTypeDatabase, FileTypeJournal, FileTypeWAL, FileTypeSHM, FileTypePos:
 		return true
 	default:
 		return false
@@ -213,6 +214,7 @@ func (f *LTXStreamFrame) WriteTo(w io.Writer) (int64, error) {
 // Invalidator is a callback for the store to use to invalidate the kernel page cache.
 type Invalidator interface {
 	InvalidateDB(db *DB, offset, size int64) error
+	InvalidatePos(db *DB) error
 }
 
 func assert(condition bool, msg string) {


### PR DESCRIPTION
This pull request adds a "-pos" suffixed file for every database that will print out the database replication position (TXID + Checksum). This file is not listed when using `ls`. I don't have a strong opinion on that but it seems like it could add clutter to the `ls` output.

Original PR contributed by @jwhear: https://github.com/jwhear/litefs/pull/3

Fixes #42 

## Usage

```sh
# Create database with a table.
$ sqlite3 /mnt/db "CREATE TABLE t (x)"

$ cat /mnt/db-pos
0000000000000001/a33a614c099fbe7e

# Update the database and the position should change.
$ sqlite3 /mnt/db "INSERT INTO t VALUES (100)"

$ cat /mnt/db-pos
0000000000000002/e26f480a1d612519
``` 