### PR TITLE
Return hostname in primary file

### DIFF
--- a/cmd/litefs/etc/litefs.yml
+++ b/cmd/litefs/etc/litefs.yml
@@ -39,6 +39,10 @@ consul:
   # Required. The URL that litefs is accessible on.
   advertise-url: "http://localhost:20202"
 
+  # Sets the hostname that other nodes will use to reference this node.
+  # Automatically assigned based on hostname(1) if not set.
+  hostname: "localhost"
+
   # The key used for obtaining a lease by the primary.
   # This must be unique for each cluster of LiteFS servers
   key: "litefs/primary"
@@ -61,5 +65,8 @@ static:
   # Specifies that the current node is the primary.
   primary: true
 
-  # The URL of the primary node.
-  primary-url: "http://localhost:20202"
+  # Required. Hostname of the primary node.
+  hostname: "localhost"
+
+  # Required. The API URL of the primary node.
+  advertise-url: "http://localhost:20202"

--- a/fuse/primary_node.go
+++ b/fuse/primary_node.go
@@ -28,18 +28,24 @@ func newPrimaryNode(fsys *FileSystem) *PrimaryNode {
 }
 
 func (n *PrimaryNode) Attr(ctx context.Context, attr *fuse.Attr) error {
+	info := n.fsys.store.PrimaryInfo()
+	if info == nil {
+		return fuse.Errno(syscall.ENOENT)
+	}
+
 	attr.Mode = 0444
+	attr.Size = uint64(len(info.Hostname) + 1)
 	attr.Uid = uint32(n.fsys.Uid)
 	attr.Gid = uint32(n.fsys.Gid)
 	return nil
 }
 
 func (n *PrimaryNode) ReadAll(ctx context.Context) ([]byte, error) {
-	primaryURL := n.fsys.store.PrimaryURL()
-	if primaryURL == "" {
+	info := n.fsys.store.PrimaryInfo()
+	if info == nil {
 		return nil, fuse.Errno(syscall.ENOENT)
 	}
-	return []byte(primaryURL + "\n"), nil
+	return []byte(info.Hostname + "\n"), nil
 }
 
 func (n *PrimaryNode) Forget() { n.fsys.root.ForgetNode(n) }

--- a/fuse/root_node.go
+++ b/fuse/root_node.go
@@ -85,8 +85,8 @@ func (n *RootNode) Lookup(ctx context.Context, name string) (node fs.Node, err e
 }
 
 func (n *RootNode) lookupPrimaryNode(ctx context.Context) (fs.Node, error) {
-	primaryURL := n.fsys.store.PrimaryURL()
-	if primaryURL == "" {
+	info := n.fsys.store.PrimaryInfo()
+	if info == nil {
 		return nil, syscall.ENOENT
 	}
 	return newPrimaryNode(n.fsys), nil
@@ -247,7 +247,7 @@ func NewRootHandle(node *RootNode) *RootHandle {
 
 func (h *RootHandle) ReadDirAll(ctx context.Context) (ents []fuse.Dirent, err error) {
 	// Show ".primary" file if this is a replica currently connected to the primary.
-	if primaryURL := h.node.fsys.store.PrimaryURL(); primaryURL != "" {
+	if info := h.node.fsys.store.PrimaryInfo(); info != nil {
 		ents = append(ents, fuse.Dirent{
 			Name: PrimaryFilename,
 			Type: fuse.DT_File,

--- a/lease_test.go
+++ b/lease_test.go
@@ -9,15 +9,17 @@ import (
 
 func TestStaticLeaser(t *testing.T) {
 	t.Run("Primary", func(t *testing.T) {
-		l := litefs.NewStaticLeaser(true, "http://localhost:20202")
+		l := litefs.NewStaticLeaser(true, "localhost", "http://localhost:20202")
 		if got, want := l.AdvertiseURL(), "http://localhost:20202"; got != want {
 			t.Fatalf("got %q, want %q", got, want)
 		}
 
-		if primaryURL, err := l.PrimaryURL(context.Background()); err != litefs.ErrNoPrimary {
+		if info, err := l.PrimaryInfo(context.Background()); err != litefs.ErrNoPrimary {
 			t.Fatal(err)
-		} else if got, want := primaryURL, ""; got != want {
-			t.Fatalf("got %q, want %q", got, want)
+		} else if got, want := info.Hostname, ""; got != want {
+			t.Fatalf("Hostname=%q, want %q", got, want)
+		} else if got, want := info.AdvertiseURL, ""; got != want {
+			t.Fatalf("AdvertiseURL=%q, want %q", got, want)
 		}
 
 		if lease, err := l.Acquire(context.Background()); err != nil {
@@ -31,15 +33,17 @@ func TestStaticLeaser(t *testing.T) {
 		}
 	})
 	t.Run("Replica", func(t *testing.T) {
-		l := litefs.NewStaticLeaser(false, "http://localhost:20202")
+		l := litefs.NewStaticLeaser(false, "localhost", "http://localhost:20202")
 		if got, want := l.AdvertiseURL(), ""; got != want {
 			t.Fatalf("got %q, want %q", got, want)
 		}
 
-		if primaryURL, err := l.PrimaryURL(context.Background()); err != nil {
+		if info, err := l.PrimaryInfo(context.Background()); err != nil {
 			t.Fatal(err)
-		} else if got, want := primaryURL, "http://localhost:20202"; got != want {
-			t.Fatalf("got %q, want %q", got, want)
+		} else if got, want := info.Hostname, "localhost"; got != want {
+			t.Fatalf("Hostname=%q, want %q", got, want)
+		} else if got, want := info.AdvertiseURL, "http://localhost:20202"; got != want {
+			t.Fatalf("AdvertiseURL=%q, want %q", got, want)
 		}
 
 		if lease, err := l.Acquire(context.Background()); err != litefs.ErrPrimaryExists {
@@ -51,7 +55,7 @@ func TestStaticLeaser(t *testing.T) {
 }
 
 func TestStaticLease(t *testing.T) {
-	leaser := litefs.NewStaticLeaser(true, "http://localhost:20202")
+	leaser := litefs.NewStaticLeaser(true, "localhost", "http://localhost:20202")
 	lease, err := leaser.Acquire(context.Background())
 	if err != nil {
 		t.Fatal(err)

--- a/store_test.go
+++ b/store_test.go
@@ -89,6 +89,21 @@ func TestStore_Open(t *testing.T) {
 	})
 }
 
+func TestPrimaryInfo_Clone(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		info := &litefs.PrimaryInfo{Hostname: "foo", AdvertiseURL: "bar"}
+		if other := info.Clone(); *other != *info {
+			t.Fatal("mismatch")
+		}
+	})
+	t.Run("Nil", func(t *testing.T) {
+		var info *litefs.PrimaryInfo
+		if other := info.Clone(); other != nil {
+			t.Fatal("expected nil")
+		}
+	})
+}
+
 // newStore returns a new instance of a Store on a temporary directory.
 // This store will automatically close when the test ends.
 func newStore(tb testing.TB) *litefs.Store {


### PR DESCRIPTION
Previously, the `.primary` file returns the advertise URL of the primary node. This is not terribly helpful for the replica node since they are not interested in contacting the LiteFS API.

This pull request changes the functionality so that `.primary` returns the hostname of the primary node. This can be set on the `static` lease by setting the `hostname` field. For Consul users, there is also a `hostname` field under `consul`, however, this field will default to the kernel's `hostname(1)` if unset.

The contents of the `.primary` file ends with a `\n` character so client applications should trim space before using.

## Usage

### Static lease

```yml
static:
  hostname: "myhost"
```

### Consul

```yml
consul:
  hostname: "myhost"
```

### Reading from the primary file

From a connected replica node:

```sh
$ cat /mnt/.primary
myhost
```