### PR TITLE
Fix database locks to use LockOwner

### DIFF
--- a/db.go
+++ b/db.go
@@ -104,6 +104,13 @@ func (db *DB) JournalPath() string {
 	return filepath.Join(db.path, "journal")
 }
 
+// PageSize returns the page size of the underlying database.
+func (db *DB) PageSize() uint32 {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return db.pageSize
+}
+
 // Pos returns the current transaction position of the database.
 func (db *DB) Pos() Pos {
 	db.mu.Lock()
@@ -181,7 +188,7 @@ func (db *DB) recoverFromLTX() error {
 		if err != nil {
 			return fmt.Errorf("read ltx file header (%s): %w", fi.Name(), err)
 		} else if header.MaxTXID != maxTXID {
-			return fmt.Errorf("ltx header max txid mismatch: %d != %d", header.MaxTXID, maxTXID)
+			return fmt.Errorf("ltx header max txid mismatch (%s): %s != %s", fi.Name(), ltx.FormatTXID(header.MaxTXID), ltx.FormatTXID(maxTXID))
 		}
 
 		if err := db.setPos(Pos{
@@ -686,6 +693,17 @@ func (db *DB) EnforceRetention(ctx context.Context, minTime time.Time) error {
 	dbLTXBytesMetricVec.WithLabelValues(ltx.FormatDBID(db.id)).Set(float64(totalSize))
 
 	return nil
+}
+
+type dbVarJSON struct {
+	Name     string `json:"name"`
+	PageSize uint32 `json:"pageSize"`
+	TXID     string `json:"txid"`
+	Checksum string `json:"checksum"`
+
+	PendingLock  string `json:"pendingLock"`
+	SharedLock   string `json:"sharedLock"`
+	ReservedLock string `json:"reservedLock"`
 }
 
 func buildJournalPageMap(f *os.File) (map[uint32]uint64, error) {

--- a/http/server.go
+++ b/http/server.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"expvar"
 	"fmt"
 	"io"
 	"log"
@@ -109,8 +110,10 @@ func (s *Server) URL() string {
 }
 
 func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
-	if strings.HasPrefix(r.URL.Path, "/debug/pprof") {
+	if strings.HasPrefix(r.URL.Path, "/debug") {
 		switch r.URL.Path {
+		case "/debug/vars":
+			expvar.Handler().ServeHTTP(w, r)
 		case "/debug/pprof/cmdline":
 			pprof.Cmdline(w, r)
 		case "/debug/pprof/profile":

--- a/rwmutex.go
+++ b/rwmutex.go
@@ -225,6 +225,20 @@ func (g *RWMutexGuard) Unlock() {
 // RWMutexState represents the lock state of an RWMutexGuard.
 type RWMutexState int
 
+// String returns the string representation of the state.
+func (s RWMutexState) String() string {
+	switch s {
+	case RWMutexStateUnlocked:
+		return "unlocked"
+	case RWMutexStateShared:
+		return "shared"
+	case RWMutexStateExclusive:
+		return "exclusive"
+	default:
+		return fmt.Sprintf("<unknown(%d)>", s)
+	}
+}
+
 const (
 	RWMutexStateUnlocked = iota
 	RWMutexStateShared

--- a/store.go
+++ b/store.go
@@ -2,6 +2,8 @@ package litefs
 
 import (
 	"context"
+	"encoding/json"
+	"expvar"
 	"fmt"
 	"io"
 	"log"
@@ -608,6 +610,46 @@ func (s *Store) processLTXStreamFrame(ctx context.Context, frame *LTXStreamFrame
 	}
 
 	return nil
+}
+
+var _ expvar.Var = (*StoreVar)(nil)
+
+type StoreVar Store
+
+func (v *StoreVar) String() string {
+	s := (*Store)(v)
+	m := &storeVarJSON{
+		IsPrimary: s.IsPrimary(),
+		Candidate: s.candidate,
+		DBs:       make(map[string]*dbVarJSON),
+	}
+
+	for _, db := range s.DBs() {
+		pos := db.Pos()
+
+		m.DBs[ltx.FormatDBID(db.ID())] = &dbVarJSON{
+			Name:     db.Name(),
+			PageSize: db.PageSize(),
+			TXID:     ltx.FormatTXID(pos.TXID),
+			Checksum: fmt.Sprintf("%016x", pos.PostApplyChecksum),
+
+			PendingLock:  db.pendingLock.State().String(),
+			SharedLock:   db.sharedLock.State().String(),
+			ReservedLock: db.reservedLock.State().String(),
+		}
+	}
+
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "null"
+	}
+	return string(b)
+}
+
+type storeVarJSON struct {
+	IsPrimary bool                  `json:"isPrimary"`
+	Candidate bool                  `json:"candidate"`
+	DBs       map[string]*dbVarJSON `json:"dbs"`
 }
 
 // Subscriber subscribes to changes to databases in the store.


### PR DESCRIPTION
This pull request fixes lock handling by the FUSE layer. Previously I thought SQLite used OFD locks but it turns out that's not the case. This PR also includes the `GET /debug/vars` endpoint which is helpful to list out the internal state of the store & its databases.