### PR TITLE
Disconnect streams when primary status changes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - run: git config --global url.https://${GH_ACCESS_TOKEN}@github.com/.insteadOf https://github.com/
         env:

--- a/.github/workflows/release.linux.yml
+++ b/.github/workflows/release.linux.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - id: release
         uses: bruceadams/get-release@v1.2.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /src/litefs
 COPY . .

--- a/db_test.go
+++ b/db_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDB_WriteSnapshotTo(t *testing.T) {
-	db, dbh := newDB(t, newOpenStore(t), "db")
+	db, dbh := newDB(t, newOpenStore(t, newPrimaryStaticLeaser(), nil), "db")
 
 	data, _ := testdata.ReadFile("testdata/db/write-snapshot-to/database")
 
@@ -117,7 +117,7 @@ func TestDB_EnforceRetention(t *testing.T) {
 	}
 
 	t.Run("OK", func(t *testing.T) {
-		store := newOpenStore(t)
+		store := newOpenStore(t, newPrimaryStaticLeaser(), nil)
 		db, dbh := newDB(t, store, "db")
 
 		data, _ := testdata.ReadFile("testdata/db/enforce-retention/database")
@@ -174,7 +174,7 @@ func TestDB_EnforceRetention(t *testing.T) {
 	})
 
 	t.Run("MinimumCount", func(t *testing.T) {
-		store := newOpenStore(t)
+		store := newOpenStore(t, newPrimaryStaticLeaser(), nil)
 		db, dbh := newDB(t, store, "db")
 
 		data, _ := testdata.ReadFile("testdata/db/enforce-retention/database")

--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -350,6 +350,7 @@ func newFileSystem(tb testing.TB) *fuse.FileSystem {
 
 	path := tb.TempDir()
 	store := litefs.NewStore(filepath.Join(path, ".mnt"), true)
+	store.Leaser = litefs.NewStaticLeaser(true, "localhost", "http://localhost:20202")
 	if err := store.Open(); err != nil {
 		tb.Fatalf("cannot open store: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/superfly/litefs
 
-go 1.18
+go 1.19
 
 require (
 	bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05

--- a/http/server.go
+++ b/http/server.go
@@ -151,6 +151,13 @@ func (s *Server) handlePostStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Wrap context so that it cancels when the primary lease is lost.
+	r = r.WithContext(s.store.PrimaryCtx(r.Context()))
+	if err := r.Context().Err(); err != nil {
+		Error(w, r, err, http.StatusServiceUnavailable)
+		return
+	}
+
 	log.Printf("stream connected")
 	defer log.Printf("stream disconnected")
 

--- a/lease_test.go
+++ b/lease_test.go
@@ -75,3 +75,8 @@ func TestStaticLease(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// newPrimaryStaticLeaser returns a new instance of StaticLeaser for primary node testing.
+func newPrimaryStaticLeaser() *litefs.StaticLeaser {
+	return litefs.NewStaticLeaser(true, "localhost", "http://localhost:20202")
+}

--- a/mock/client.go
+++ b/mock/client.go
@@ -1,0 +1,16 @@
+package mock
+
+import (
+	"context"
+	"io"
+
+	"github.com/superfly/litefs"
+)
+
+type Client struct {
+	StreamFunc func(ctx context.Context, rawurl string, id string, posMap map[uint32]litefs.Pos) (io.ReadCloser, error)
+}
+
+func (c *Client) Stream(ctx context.Context, rawurl string, id string, posMap map[uint32]litefs.Pos) (io.ReadCloser, error) {
+	return c.StreamFunc(ctx, rawurl, id, posMap)
+}

--- a/mock/lease.go
+++ b/mock/lease.go
@@ -1,0 +1,58 @@
+package mock
+
+import (
+	"context"
+	"time"
+
+	"github.com/superfly/litefs"
+)
+
+var _ litefs.Leaser = (*Leaser)(nil)
+
+type Leaser struct {
+	CloseFunc        func() error
+	AdvertiseURLFunc func() string
+	AcquireFunc      func(ctx context.Context) (litefs.Lease, error)
+	PrimaryInfoFunc  func(ctx context.Context) (litefs.PrimaryInfo, error)
+}
+
+func (l *Leaser) Close() error {
+	return l.CloseFunc()
+}
+
+func (l *Leaser) AdvertiseURL() string {
+	return l.AdvertiseURLFunc()
+}
+
+func (l *Leaser) Acquire(ctx context.Context) (litefs.Lease, error) {
+	return l.AcquireFunc(ctx)
+}
+
+func (l *Leaser) PrimaryInfo(ctx context.Context) (litefs.PrimaryInfo, error) {
+	return l.PrimaryInfoFunc(ctx)
+}
+
+var _ litefs.Lease = (*Lease)(nil)
+
+type Lease struct {
+	RenewedAtFunc func() time.Time
+	TTLFunc       func() time.Duration
+	RenewFunc     func(ctx context.Context) error
+	CloseFunc     func() error
+}
+
+func (l *Lease) RenewedAt() time.Time {
+	return l.RenewedAtFunc()
+}
+
+func (l *Lease) TTL() time.Duration {
+	return l.TTLFunc()
+}
+
+func (l *Lease) Renew(ctx context.Context) error {
+	return l.RenewFunc(ctx)
+}
+
+func (l *Lease) Close() error {
+	return l.CloseFunc()
+}


### PR DESCRIPTION
This pull request adds `Store.PrimaryCtx()` which wraps a `context.Context` and monitors for the loss of the primary state. This is hooked into `http.Server.serveStream()` so that connections will automatically disconnect when the primary status is lost.

Helps with https://github.com/superfly/litefs/pull/80


