### PR TITLE
Remove GITHUB_TOKEN & Makefile

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -48,5 +48,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            GITHUB_TOKEN=${{ secrets.GH_ACCESS_TOKEN }}
             LITEFS_VERSION=${{ env.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,7 @@ FROM golang:1.19 as builder
 WORKDIR /src/litefs
 COPY . .
 
-ARG GITHUB_TOKEN
 ARG LITEFS_VERSION=latest
-
-RUN git config --global url."https://${GITHUB_TOKEN}:@github.com/".insteadOf "https://github.com/"
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
 	--mount=type=cache,target=/go/pkg \

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,0 @@
-.PHONY: default
-default:
-
-.PHONY: docker
-docker:
-ifndef GITHUB_TOKEN
-	$(error GITHUB_TOKEN is undefined)
-endif
-	docker build --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} -t litefs .


### PR DESCRIPTION
The `GITHUB_TOKEN` was used when LiteFS was still a private repo. Now that it's public, it's no longer needed.