### PR TITLE
Wait for ready state on startup

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -217,6 +217,15 @@ func (m *Main) Run(ctx context.Context) (err error) {
 	m.HTTPServer.Serve()
 	log.Printf("http server listening on: %s", m.HTTPServer.URL())
 
+	// Wait until the store either becomes primary or connects to the primary.
+	log.Printf("waiting to connect to cluster")
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-m.Store.ReadyCh():
+		log.Printf("connected to cluster, ready")
+	}
+
 	// Execute subcommand, if specified in config.
 	if err := m.execCmd(ctx); err != nil {
 		return fmt.Errorf("cannot exec: %w", err)

--- a/http/server.go
+++ b/http/server.go
@@ -187,6 +187,10 @@ func (s *Server) handlePostStream(w http.ResponseWriter, r *http.Request) {
 		dirtySet[db.ID()] = struct{}{}
 	}
 
+	// Flush header so client can resume control.
+	w.WriteHeader(http.StatusOK)
+	w.(http.Flusher).Flush()
+
 	// Continually iterate by writing dirty changes and then waiting for new changes.
 	for {
 		// Send pending transactions for each database.


### PR DESCRIPTION
This pull request adds a check to wait for the store to either become primary or connect to the primary before executing the subcommand (if set). Eventually it should wait until it is up to date with the primary (if connected as a replica) before proceeding.