### PR TITLE
Ensure node does not startup if LTX files are invalid

### DIFF
--- a/db.go
+++ b/db.go
@@ -415,7 +415,7 @@ func (db *DB) CommitJournal(mode JournalMode) error {
 		return fmt.Errorf("close ltx file: %s", err)
 	}
 
-	// Atomically rename the file.
+	// Atomically rename the file
 	if err := os.Rename(tmpPath, ltxPath); err != nil {
 		return fmt.Errorf("rename ltx file: %w", err)
 	} else if err := internal.Sync(filepath.Dir(ltxPath)); err != nil {

--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -82,14 +82,14 @@ func (fsys *FileSystem) Mount() (err error) {
 
 // Unmount unmounts the file system.
 func (fsys *FileSystem) Unmount() (err error) {
-	if e := fuse.Unmount(fsys.path); err == nil {
-		err = e
-	}
-
 	if fsys.conn != nil {
+		if e := fuse.Unmount(fsys.path); err == nil {
+			err = e
+		}
 		if e := fsys.conn.Close(); err == nil {
 			err = e
 		}
+		fsys.conn = nil
 	}
 	return err
 }

--- a/store.go
+++ b/store.go
@@ -197,7 +197,7 @@ func (s *Store) openDatabases() error {
 			log.Printf("not a database directory, skipping: %q", fi.Name())
 			continue
 		} else if err := s.openDatabase(dbID); err != nil {
-			return fmt.Errorf("open database: db=%s err=%w", ltx.FormatDBID(dbID), err)
+			return fmt.Errorf("open database(%s): %w", ltx.FormatDBID(dbID), err)
 		}
 	}
 


### PR DESCRIPTION
This pull request simply adds a test to verify that a node will fail if there are invalid LTX files. Right now, manual intervention is needed to remedy this issue but, eventually, LiteFS should automatically recover.