### PR TITLE
Fix locking on LTX apply

### DIFF
--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -33,7 +33,8 @@ func TestFileSystem_OK(t *testing.T) {
 			// Create a simple table with a single value.
 			if _, err := db.Exec(`CREATE TABLE t (x)`); err != nil {
 				t.Fatal(err)
-			} else if _, err := db.Exec(`INSERT INTO t VALUES (100)`); err != nil {
+			}
+			if _, err := db.Exec(`INSERT INTO t VALUES (100)`); err != nil {
 				t.Fatal(err)
 			}
 

--- a/store.go
+++ b/store.go
@@ -723,7 +723,7 @@ func (s *Store) processLTXStreamFrame(ctx context.Context, frame *LTXStreamFrame
 	dbLTXBytesMetricVec.WithLabelValues(ltx.FormatDBID(db.ID())).Set(float64(n))
 
 	// Attempt to apply the LTX file to the database.
-	if err := db.TryApplyLTX(path); err != nil {
+	if err := db.ApplyLTX(ctx, path); err != nil {
 		return fmt.Errorf("apply ltx: %w", err)
 	}
 


### PR DESCRIPTION
This pull request changes `ApplyLTX()` so it acquires exclusive locks on `RESERVED`, `SHARED`, & `PENDING` locks before applying. Locks will block until acquired or until the context is canceled. The `DB` mutex has also been moved so it is only held while the position is being updated.