### PR TITLE
Verify txid/checksum on LTX frame

### DIFF
--- a/db.go
+++ b/db.go
@@ -569,8 +569,6 @@ func (db *DB) ApplyLTX(ctx context.Context, path string) error {
 		return fmt.Errorf("decode ltx header: %s", err)
 	}
 
-	// TODO: Verify pre-checksum matches.
-
 	pageBuf := make([]byte, dec.Header().PageSize)
 	for i := 0; ; i++ {
 		// Read pgno & page data from LTX file.


### PR DESCRIPTION
This pull request adds a check to ensure the DB position matches the min TXID & the pre-apply checksum in the LTX file header. This should already be handled by the HTTP server on the primary but this is an extra check to help ensure safety.