### PR TITLE
Fix LTX checksum on VACUUM

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -284,6 +284,7 @@ func (m *Main) initStore(ctx context.Context) error {
 	}
 
 	m.Store = litefs.NewStore(dataDir, m.Config.Candidate)
+	m.Store.StrictVerify = m.Config.StrictVerify
 	m.Store.RetentionDuration = m.Config.Retention.Duration
 	m.Store.RetentionMonitorInterval = m.Config.Retention.MonitorInterval
 	m.Store.Client = http.NewClient()
@@ -361,11 +362,12 @@ var expvarOnce sync.Once
 
 // Config represents a configuration for the binary process.
 type Config struct {
-	MountDir  string `yaml:"mount-dir"`
-	DataDir   string `yaml:"data-dir"`
-	Exec      string `yaml:"exec"`
-	Debug     bool   `yaml:"debug"`
-	Candidate bool   `yaml:"candidate"`
+	MountDir     string `yaml:"mount-dir"`
+	DataDir      string `yaml:"data-dir"`
+	Exec         string `yaml:"exec"`
+	Candidate    bool   `yaml:"candidate"`
+	Debug        bool   `yaml:"debug"`
+	StrictVerify bool   `yaml:"-"`
 
 	Retention RetentionConfig `yaml:"retention"`
 	HTTP      HTTPConfig      `yaml:"http"`

--- a/cmd/litefs/main_test.go
+++ b/cmd/litefs/main_test.go
@@ -535,6 +535,7 @@ func newMain(tb testing.TB, mountDir string, peer *main.Main) *main.Main {
 	m := main.NewMain()
 	m.Config.MountDir = mountDir
 	m.Config.Debug = *debug
+	m.Config.StrictVerify = true
 	m.Config.HTTP.Addr = ":0"
 	m.Config.Consul = &main.ConsulConfig{
 		URL:       "http://localhost:8500",

--- a/fuse/root_node.go
+++ b/fuse/root_node.go
@@ -196,7 +196,11 @@ func (n *RootNode) Remove(ctx context.Context, req *fuse.RemoveRequest) (err err
 
 	switch fileType {
 	case litefs.FileTypeJournal:
-		return db.CommitJournal(litefs.JournalModeDelete)
+		if err := db.CommitJournal(litefs.JournalModeDelete); err != nil {
+			log.Printf("fuse: commit error: %s", err)
+			return err
+		}
+		return nil
 	default:
 		return fuse.ToErrno(syscall.ENOSYS)
 	}

--- a/store.go
+++ b/store.go
@@ -63,6 +63,10 @@ type Store struct {
 
 	// Callback to notify kernel of file changes.
 	Invalidator Invalidator
+
+	// If true, computes and verifies the checksum of the entire database
+	// after every transaction. Should only be used during testing.
+	StrictVerify bool
 }
 
 // NewStore returns a new instance of Store.


### PR DESCRIPTION
This also adds a "StrictVerify" mode to the `Store` so that it re-computes the entire database checksum on every transaction. It's only intended to be used during testing.