### PR TITLE
Implement write forwarding

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -300,7 +300,12 @@ func (m *Main) openStore(ctx context.Context) error {
 func (m *Main) initFileSystem(ctx context.Context) error {
 	// Build the file system to interact with the store.
 	fsys := fuse.NewFileSystem(m.Config.MountDir, m.Store)
-	fsys.Debug = m.Config.Debug
+
+	// Log the store information with each log message.
+	if m.Config.Debug {
+		fsys.Debug = fuse.Debug(m.Store)
+	}
+
 	if err := fsys.Mount(); err != nil {
 		return fmt.Errorf("cannot open file system: %s", err)
 	}

--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -30,7 +30,7 @@ type FileSystem struct {
 	Gid int
 
 	// If true, logs debug information about every FUSE call.
-	Debug bool
+	Debug func(msg any)
 }
 
 // NewFileSystem returns a new instance of FileSystem.
@@ -64,10 +64,7 @@ func (fsys *FileSystem) Mount() (err error) {
 		return err
 	}
 
-	var config fs.Config
-	if fsys.Debug {
-		config.Debug = func(msg interface{}) { log.Print(msg) }
-	}
+	config := fs.Config{Debug: fsys.Debug}
 
 	fsys.server = fs.New(fsys.conn, &config)
 
@@ -120,8 +117,8 @@ func (fsys *FileSystem) Statfs(ctx context.Context, req *fuse.StatfsRequest, res
 	return nil
 }
 
-// InvalidateDB invalidates a database in the kernel page cache.
-func (fsys *FileSystem) InvalidateDB(db *litefs.DB, offset, size int64) error {
+// InvalidateDBRange invalidates a database in the kernel page cache.
+func (fsys *FileSystem) InvalidateDBRange(db *litefs.DB, offset, size int64) error {
 	node := fsys.root.Node(db.Name())
 	if node == nil {
 		return nil

--- a/fuse/fuse.go
+++ b/fuse/fuse.go
@@ -2,6 +2,7 @@ package fuse
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"syscall"
@@ -60,3 +61,14 @@ type Error struct {
 
 func (e *Error) Errno() fuse.Errno { return e.errno }
 func (e *Error) Error() string     { return e.err.Error() }
+
+// Debug returns a logging function for use with fuse.Options.Debug.
+func Debug(store *litefs.Store) func(any) {
+	return func(msg any) {
+		status := "r"
+		if store.IsPrimary() {
+			status = "p"
+		}
+		log.Printf("%s [%s]: %s", store.ID(), status, msg)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -49,3 +49,4 @@ require (
 replace github.com/mattn/go-sqlite3 => github.com/benbjohnson/go-sqlite3 v0.0.0-20220723145740-eed275a583e0
 
 // replace github.com/superfly/ltx => ../ltx
+// replace golang.org/x/net => ../../golang.org/x/net

--- a/http/client.go
+++ b/http/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
@@ -36,11 +37,68 @@ func NewClient() *Client {
 	}
 }
 
-// Stream returns a snapshot and continuous stream of WAL updates.
-func (c *Client) Stream(ctx context.Context, rawurl string, nodeID string, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
-	u, err := url.Parse(rawurl)
+func (c *Client) Begin(ctx context.Context, primaryURL string, nodeID, name string) (_ litefs.Tx, retErr error) {
+	u, err := url.Parse(primaryURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid client URL: %w", err)
+		return nil, fmt.Errorf("invalid primary URL: %w", err)
+	} else if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("invalid URL scheme")
+	} else if u.Host == "" {
+		return nil, fmt.Errorf("URL host required")
+	}
+
+	// Strip off everything but the scheme & host.
+	*u = url.URL{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+		Path:   "/tx",
+		RawQuery: (url.Values{
+			"name": []string{name},
+		}).Encode(),
+	}
+
+	pr, pw := io.Pipe()
+	req, err := http.NewRequest("POST", u.String(), io.NopCloser(pr))
+	if err != nil {
+		return nil, err
+	}
+	// req = req.WithContext(ctx)
+	req.Header.Set("Litefs-Id", nodeID)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// If unsuccessful, close stream and return an error.
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("invalid response: code=%d", resp.StatusCode)
+	}
+
+	// Otherwise capture transaction info and return it to the caller to complete the transaction.
+	tx := &Tx{w: pw, r: resp.Body}
+	defer func() {
+		if retErr != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := binary.Read(resp.Body, binary.BigEndian, &tx.id); err != nil {
+		return nil, fmt.Errorf("read txid: %w", err)
+	}
+	if err := binary.Read(resp.Body, binary.BigEndian, &tx.preApplyChecksum); err != nil {
+		return nil, fmt.Errorf("read pre-apply checksum: %w", err)
+	}
+
+	return tx, nil
+}
+
+// Stream returns a snapshot and continuous stream of WAL updates.
+func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID string, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
+	u, err := url.Parse(primaryURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid primary URL: %w", err)
 	} else if u.Scheme != "http" && u.Scheme != "https" {
 		return nil, fmt.Errorf("invalid URL scheme")
 	} else if u.Host == "" {
@@ -75,4 +133,44 @@ func (c *Client) Stream(ctx context.Context, rawurl string, nodeID string, posMa
 		return nil, fmt.Errorf("invalid response: code=%d", resp.StatusCode)
 	}
 	return resp.Body, nil
+}
+
+// Tx represents a remote transaction created by Client.Begin().
+type Tx struct {
+	id               uint64
+	preApplyChecksum uint64
+
+	w io.WriteCloser // request body
+	r io.ReadCloser  // response body
+}
+
+// ID returns the TXID of the transaction.
+func (tx *Tx) ID() uint64 { return tx.id }
+
+// PreApplyChecksum returns checksum of the database before the transaction is applied.
+func (tx *Tx) PreApplyChecksum() uint64 { return tx.preApplyChecksum }
+
+// Commit send the LTX data from r to the remote primary for commit.
+func (tx *Tx) Commit(r io.Reader) error {
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := io.Copy(tx.w, r); err != nil {
+		return fmt.Errorf("copy ltx file: %w", err)
+	}
+
+	// TODO: Read confirmation from primary.
+
+	return nil
+}
+
+// Rollback closes the connection without sending a transaction, thus rolling back.
+func (tx *Tx) Rollback() error {
+	if err := tx.w.Close(); err != nil {
+		_ = tx.r.Close()
+		return fmt.Errorf("close writer: %w", err)
+	}
+	if err := tx.r.Close(); err != nil {
+		return fmt.Errorf("close reader: %w", err)
+	}
+	return nil
 }

--- a/http/server.go
+++ b/http/server.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"encoding/binary"
 	"expvar"
 	"fmt"
 	"io"
@@ -143,6 +144,14 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch r.URL.Path {
+	case "/tx":
+		switch r.Method {
+		case http.MethodPost:
+			s.handlePostTx(w, r)
+		default:
+			Error(w, r, fmt.Errorf("method not allowed"), http.StatusMethodNotAllowed)
+		}
+
 	case "/stream":
 		switch r.Method {
 		case http.MethodPost:
@@ -153,6 +162,57 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.NotFound(w, r)
 	}
+}
+
+func (s *Server) handlePostTx(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	name := q.Get("name")
+
+	db, err := s.store.CreateDBIfNotExists(name)
+	if err != nil {
+		Error(w, r, fmt.Errorf("create db: %w", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Acquire file locks on the database for the transction.
+	gs := db.GuardSet()
+	defer gs.Unlock() // release on connection close
+
+	if err := gs.Reserved().Lock(r.Context()); err != nil {
+		Error(w, r, fmt.Errorf("acquire RESERVED lock: %w", err), http.StatusInternalServerError)
+		return
+	}
+	if err := gs.Shared().Lock(r.Context()); err != nil {
+		Error(w, r, fmt.Errorf("acquire SHARED lock: %w", err), http.StatusInternalServerError)
+		return
+	}
+	if err := gs.Pending().Lock(r.Context()); err != nil {
+		Error(w, r, fmt.Errorf("acquire PENDING lock: %w", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Write transaction metadata back to client.
+	pos := db.Pos()
+	txID, preApplyChecksum := uint64(pos.TXID+1), pos.PostApplyChecksum
+	if err := binary.Write(w, binary.BigEndian, txID); err != nil {
+		Error(w, r, fmt.Errorf("write txid: %w", err), http.StatusInternalServerError)
+		return
+	}
+	if err := binary.Write(w, binary.BigEndian, preApplyChecksum); err != nil {
+		Error(w, r, fmt.Errorf("write pre-apply checksum: %w", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.(http.Flusher).Flush()
+
+	// Apply transaction to database.
+	if err := db.ApplyLTX(r.Context(), r.Body, false); err != nil {
+		Error(w, r, err, http.StatusInternalServerError)
+		return
+	}
+
+	// TODO: Return confirmation in trailer, maybe?
+
 }
 
 func (s *Server) handlePostStream(w http.ResponseWriter, r *http.Request) {
@@ -319,7 +379,7 @@ func (s *Server) streamLTXSnapshot(ctx context.Context, w http.ResponseWriter, d
 }
 
 func Error(w http.ResponseWriter, r *http.Request, err error, code int) {
-	log.Printf("http: error: %s", err)
+	log.Printf("http: %s %s: error: %s", r.Method, r.URL.Path, err)
 	http.Error(w, err.Error(), code)
 }
 

--- a/litefs.go
+++ b/litefs.go
@@ -18,6 +18,9 @@ var (
 	ErrLeaseExpired  = errors.New("lease expired")
 
 	ErrReadOnlyReplica = fmt.Errorf("read only replica")
+
+	ErrStaleTx          = fmt.Errorf("stale tx")
+	ErrDuplicateLTXFile = fmt.Errorf("duplicate ltx file")
 )
 
 // SQLite constants
@@ -29,9 +32,9 @@ const (
 
 // SQLite rollback journal lock constants.
 const (
-	PENDING_BYTE  = 0x40000000
-	RESERVED_BYTE = (PENDING_BYTE + 1)
-	SHARED_FIRST  = (PENDING_BYTE + 2)
+	PENDING_BYTE  = 0x40000000         // 1073741824
+	RESERVED_BYTE = (PENDING_BYTE + 1) // 1073741825
+	SHARED_FIRST  = (PENDING_BYTE + 2) // 1073741826..1073742335
 	SHARED_SIZE   = 510
 )
 
@@ -105,8 +108,11 @@ func (p Pos) IsZero() bool {
 
 // Client represents a client for connecting to other LiteFS nodes.
 type Client interface {
+	// Begin starts a remote transaction on the primary node.
+	Begin(ctx context.Context, primaryURL string, nodeID, name string) (Tx, error)
+
 	// Stream starts a long-running connection to stream changes from another node.
-	Stream(ctx context.Context, rawurl string, id string, posMap map[string]Pos) (io.ReadCloser, error)
+	Stream(ctx context.Context, primaryURL string, nodeID string, posMap map[string]Pos) (io.ReadCloser, error)
 }
 
 type StreamFrameType uint32
@@ -207,7 +213,7 @@ func (f *ReadyStreamFrame) WriteTo(w io.Writer) (int64, error) {
 
 // Invalidator is a callback for the store to use to invalidate the kernel page cache.
 type Invalidator interface {
-	InvalidateDB(db *DB, offset, size int64) error
+	InvalidateDBRange(db *DB, offset, size int64) error
 	InvalidatePos(db *DB) error
 }
 

--- a/mock/client.go
+++ b/mock/client.go
@@ -7,10 +7,33 @@ import (
 	"github.com/superfly/litefs"
 )
 
+var _ litefs.Client = (*Client)(nil)
+
 type Client struct {
-	StreamFunc func(ctx context.Context, rawurl string, id string, posMap map[string]litefs.Pos) (io.ReadCloser, error)
+	BeginFunc  func(ctx context.Context, primaryURL string, nodeID, name string) (litefs.Tx, error)
+	StreamFunc func(ctx context.Context, primaryURL string, nodeID string, posMap map[string]litefs.Pos) (io.ReadCloser, error)
 }
 
-func (c *Client) Stream(ctx context.Context, rawurl string, id string, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
-	return c.StreamFunc(ctx, rawurl, id, posMap)
+func (c *Client) Begin(ctx context.Context, primaryURL string, nodeID, name string) (litefs.Tx, error) {
+	return c.BeginFunc(ctx, primaryURL, nodeID, name)
 }
+
+func (c *Client) Stream(ctx context.Context, primaryURL string, id string, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
+	return c.StreamFunc(ctx, primaryURL, id, posMap)
+}
+
+var _ litefs.Tx = (*Tx)(nil)
+
+type Tx struct {
+	IDFunc               func() uint64
+	PreApplyChecksumFunc func() uint64
+
+	CommitFunc   func(r io.Reader) error
+	RollbackFunc func() error
+}
+
+func (tx *Tx) ID() uint64               { return tx.IDFunc() }
+func (tx *Tx) PreApplyChecksum() uint64 { return tx.PreApplyChecksumFunc() }
+
+func (tx *Tx) Commit(r io.Reader) error { return tx.CommitFunc(r) }
+func (tx *Tx) Rollback() error          { return tx.RollbackFunc() }

--- a/rwmutex.go
+++ b/rwmutex.go
@@ -101,6 +101,13 @@ func (g *RWMutexGuard) TryLock() bool {
 	}
 }
 
+// HasLock returns true if the guard has an exclusive lock.
+func (g *RWMutexGuard) HasLock() bool {
+	g.rw.mu.Lock()
+	defer g.rw.mu.Unlock()
+	return g.state == RWMutexStateExclusive
+}
+
 // CanLock returns true if the guard can become an exclusive lock.
 func (g *RWMutexGuard) CanLock() bool {
 	g.rw.mu.Lock()

--- a/store.go
+++ b/store.go
@@ -3,7 +3,7 @@ package litefs
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
+	crand "crypto/rand"
 	"encoding/json"
 	"expvar"
 	"fmt"
@@ -16,7 +16,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/superfly/litefs/internal"
 	"github.com/superfly/ltx"
 	"golang.org/x/sync/errgroup"
 )
@@ -28,6 +27,8 @@ const IDLength = 24
 const (
 	DefaultRetentionDuration        = 1 * time.Minute
 	DefaultRetentionMonitorInterval = 1 * time.Minute
+
+	DefaultBeginTimeout = 30 * time.Second
 )
 
 // Store represents a collection of databases.
@@ -59,6 +60,9 @@ type Store struct {
 	RetentionDuration        time.Duration
 	RetentionMonitorInterval time.Duration
 
+	// Transaction timeouts.
+	BeginTimeout time.Duration
+
 	// Callback to notify kernel of file changes.
 	Invalidator Invalidator
 
@@ -84,6 +88,8 @@ func NewStore(path string, candidate bool) *Store {
 
 		RetentionDuration:        DefaultRetentionDuration,
 		RetentionMonitorInterval: DefaultRetentionMonitorInterval,
+
+		BeginTimeout: DefaultBeginTimeout,
 	}
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 
@@ -152,10 +158,10 @@ func (s *Store) initID() error {
 
 	// Generate a new node ID if file doesn't exist.
 	b := make([]byte, IDLength/2)
-	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+	if _, err := io.ReadFull(crand.Reader, b); err != nil {
 		return fmt.Errorf("generate id: %w", err)
 	}
-	id := fmt.Sprintf("%x", b)
+	id := fmt.Sprintf("%X", b)
 
 	f, err := os.Create(filename)
 	if err != nil {
@@ -308,6 +314,55 @@ func (s *Store) DBs() []*DB {
 		a = append(a, db)
 	}
 	return a
+}
+
+// Begin begins a remote transaction if this node is not the primary.
+func (s *Store) Begin(ctx context.Context, name string) (retErr error) {
+	s.mu.Lock()
+	isPrimary, info := s.isPrimary, s.primaryInfo
+	s.mu.Unlock()
+
+	// Ensure database exists.
+	db, err := s.CreateDBIfNotExists(name)
+	if err != nil {
+		return fmt.Errorf("create database %q: %w", name, err)
+	}
+
+	// If local node is not the primary, issue the transaction on the remote node.
+	if isPrimary {
+		return nil // no remote tx required
+	} else if info == nil {
+		return fmt.Errorf("cannot start tx, not primary & not connected to primary")
+	}
+
+	// Otherwise connect to the primary to begin a remote write.
+	tx, err := s.Client.Begin(ctx, info.AdvertiseURL, s.id, name)
+	if err != nil {
+		return fmt.Errorf("remote begin: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Persist transaction so we can commit/rollback later.
+	db.mu.Lock()
+	db.tx = tx
+	db.mu.Unlock()
+
+	println("dbg/BEGIN", ltx.FormatTXID(tx.ID()), "-", db.Pos().String())
+
+	if tx.ID()-1 != db.Pos().TXID {
+		return ErrStaleTx
+	}
+
+	// Wait for local node to catch up to remote position. Verify that checksums match at TXID.
+	//if err := db.WaitPos(ctx, Pos{TXID: tx.ID() - 1, PostApplyChecksum: tx.PreApplyChecksum()}); err != nil {
+	//	return fmt.Errorf("wait: %w", err)
+	//}
+
+	return nil
 }
 
 // CreateDB creates a new database with the given name. The returned file handle
@@ -641,67 +696,12 @@ func (s *Store) processLTXStreamFrame(ctx context.Context, frame *LTXStreamFrame
 		return fmt.Errorf("create database: %w", err)
 	}
 
-	r := ltx.NewReader(src)
-	if err := r.PeekHeader(); err != nil {
-		return fmt.Errorf("peek ltx header: %w", err)
-	}
-
-	// Exit if LTX file does already exists.
-	path := db.LTXPath(r.Header().MinTXID, r.Header().MaxTXID)
-	if _, err := os.Stat(path); err == nil {
-		log.Printf("ltx file already exists, skipping: %s", path)
+	if err := db.ApplyLTX(ctx, src, true); err == ErrDuplicateLTXFile {
+		log.Printf("ltx file already exists, skipping")
 		return nil
-	}
-
-	// Verify LTX file pre-apply checksum matches the current database position
-	// unless this is a snapshot, which will overwrite all data.
-	if hdr := r.Header(); !hdr.IsSnapshot() {
-		expectedPos := Pos{
-			TXID:              r.Header().MinTXID - 1,
-			PostApplyChecksum: r.Header().PreApplyChecksum,
-		}
-		if pos := db.Pos(); pos != expectedPos {
-			return fmt.Errorf("position mismatch on db %q: %s <> %s", db.Name(), pos, expectedPos)
-		}
-	}
-
-	// TODO: Remove all LTX files if this is a snapshot.
-
-	// Write LTX file to a temporary file and we'll atomically rename later.
-	tmpPath := path + ".tmp"
-	defer func() { _ = os.Remove(tmpPath) }()
-
-	f, err := os.Create(tmpPath)
-	if err != nil {
-		return fmt.Errorf("cannot create temp ltx file: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	n, err := io.Copy(f, r)
-	if err != nil {
-		return fmt.Errorf("write ltx file: %w", err)
-	} else if err := f.Sync(); err != nil {
-		return fmt.Errorf("fsync ltx file: %w", err)
-	}
-
-	// Atomically rename file.
-	if err := os.Rename(tmpPath, path); err != nil {
-		return fmt.Errorf("rename ltx file: %w", err)
-	} else if err := internal.Sync(filepath.Dir(path)); err != nil {
-		return fmt.Errorf("sync ltx dir: %w", err)
-	}
-
-	log.Printf("recv frame<ltx>: db=%q tx=%s-%s size=%d", db.Name(), ltx.FormatTXID(r.Header().MinTXID), ltx.FormatTXID(r.Header().MaxTXID), n)
-
-	// Update metrics
-	dbLTXCountMetricVec.WithLabelValues(db.Name()).Inc()
-	dbLTXBytesMetricVec.WithLabelValues(db.Name()).Set(float64(n))
-
-	// Attempt to apply the LTX file to the database.
-	if err := db.ApplyLTX(ctx, path); err != nil {
+	} else if err != nil {
 		return fmt.Errorf("apply ltx: %w", err)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
This pull request implements the ability for a non-primary node to borrow the lock on a database, execute a write transaction, and then ship the resulting LTX file back to the primary for replication. This results in a slower transaction than if the write were issued directly on the primary because it requires 2 round trips. However, it allows for easier usage as writes can be directed to a single region instead of being directed to a single node.

_Note: The commit & rollback are implemented but this PR still needs some clean up._