### PR TITLE
Require explicit data directory

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -177,7 +177,9 @@ func (m *Main) Close() (err error) {
 
 func (m *Main) Run(ctx context.Context) (err error) {
 	if m.Config.MountDir == "" {
-		return fmt.Errorf("mount path required")
+		return fmt.Errorf("mount directory required")
+	} else if m.Config.DataDir == "" {
+		return fmt.Errorf("data directory required")
 	}
 
 	// Enforce exactly one lease mode.
@@ -275,15 +277,7 @@ func (m *Main) initConsul(ctx context.Context) (err error) {
 }
 
 func (m *Main) initStore(ctx context.Context) error {
-	// Load the data directory from the config.
-	// Default to use a hidden directory next to the mount, if not specified.
-	dataDir := m.Config.DataDir
-	if dataDir == "" {
-		dir, file := filepath.Split(m.Config.MountDir)
-		dataDir = filepath.Join(dir, "."+file)
-	}
-
-	m.Store = litefs.NewStore(dataDir, m.Config.Candidate)
+	m.Store = litefs.NewStore(m.Config.DataDir, m.Config.Candidate)
 	m.Store.StrictVerify = m.Config.StrictVerify
 	m.Store.RetentionDuration = m.Config.Retention.Duration
 	m.Store.RetentionMonitorInterval = m.Config.Retention.MonitorInterval

--- a/cmd/litefs/main_test.go
+++ b/cmd/litefs/main_test.go
@@ -524,17 +524,18 @@ func TestConfigExample(t *testing.T) {
 	}
 }
 
-func newMain(tb testing.TB, mountDir string, peer *main.Main) *main.Main {
+func newMain(tb testing.TB, dir string, peer *main.Main) *main.Main {
 	tb.Helper()
 
 	tb.Cleanup(func() {
-		if err := os.RemoveAll(mountDir); err != nil {
+		if err := os.RemoveAll(dir); err != nil {
 			tb.Fatalf("cannot remove temp directory: %s", err)
 		}
 	})
 
 	m := main.NewMain()
-	m.Config.MountDir = mountDir
+	m.Config.MountDir = filepath.Join(dir, "mnt")
+	m.Config.DataDir = filepath.Join(dir, "data")
 	m.Config.Debug = *debug
 	m.Config.StrictVerify = true
 	m.Config.HTTP.Addr = ":0"
@@ -543,6 +544,11 @@ func newMain(tb testing.TB, mountDir string, peer *main.Main) *main.Main {
 		Key:       fmt.Sprintf("%x", rand.Int31()),
 		TTL:       10 * time.Second,
 		LockDelay: 1 * time.Second,
+	}
+
+	// Ensure mount directory exists.
+	if err := os.MkdirAll(m.Config.MountDir, 0777); err != nil {
+		tb.Fatal(err)
 	}
 
 	// Use peer's consul key, if passed in.


### PR DESCRIPTION
Previously, the `data-dir` was generated based on the path of the mount directory. However, this was confusing as persistent volumes need to be mounted to a directory with an explicit path so it's better to require `data-dir` to be explicit as well.