### PR TITLE
Only release amd64 and arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,6 @@ jobs:
             cc:   gcc
           - arch: arm64
             cc:   aarch64-linux-gnu-gcc
-          - arch: arm
-            arm:  6
-            cc:   arm-linux-gnueabi-gcc
-          - arch: arm
-            arm:  7
-            cc:   arm-linux-gnueabihf-gcc
 
     env:
       GOOS:   linux


### PR DESCRIPTION
Removing arm6 & arm7 builds until more testing can be done with them.