### PR TITLE
Support MacOS

### DIFF
--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -1,10 +1,8 @@
 package fuse
 
 import (
-	"context"
 	"log"
 	"os"
-	"syscall"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
@@ -93,27 +91,6 @@ func (fsys *FileSystem) Unmount() (err error) {
 // Root returns the root directory in the file system.
 func (fsys *FileSystem) Root() (fs.Node, error) {
 	return fsys.root, nil
-}
-
-// Statfs is a passthrough to the underlying file system.
-func (fsys *FileSystem) Statfs(ctx context.Context, req *fuse.StatfsRequest, resp *fuse.StatfsResponse) error {
-	// Obtain statfs() call from underlying store path.
-	var statfs syscall.Statfs_t
-	if err := syscall.Statfs(fsys.store.Path(), &statfs); err != nil {
-		return err
-	}
-
-	// Copy stats over from the underlying file system to the response.
-	resp.Blocks = statfs.Blocks
-	resp.Bfree = statfs.Bfree
-	resp.Bavail = statfs.Bavail
-	resp.Files = statfs.Files
-	resp.Ffree = statfs.Ffree
-	resp.Bsize = uint32(statfs.Bsize)
-	resp.Namelen = uint32(statfs.Namelen)
-	resp.Frsize = uint32(statfs.Frsize)
-
-	return nil
 }
 
 // InvalidateDB invalidates a database in the kernel page cache.

--- a/fuse/statfs-notdarwin.go
+++ b/fuse/statfs-notdarwin.go
@@ -1,0 +1,32 @@
+// This looks like it's unlikely to work on Windows but I've just fixed MacOS for now.
+
+//go:build !darwin
+
+package fuse
+
+import (
+	"syscall"
+
+	"bazil.org/fuse"
+)
+
+// Statfs is a passthrough to the underlying file system.
+func (fsys *FileSystem) Statfs(ctx context.Context, req *fuse.StatfsRequest, resp *fuse.StatfsResponse) error {
+	// Obtain statfs() call from underlying store path.
+	var statfs syscall.Statfs_t
+	if err := syscall.Statfs(fsys.store.Path(), &statfs); err != nil {
+		return err
+	}
+
+	// Copy stats over from the underlying file system to the response.
+	resp.Blocks = statfs.Blocks
+	resp.Bfree = statfs.Bfree
+	resp.Bavail = statfs.Bavail
+	resp.Files = statfs.Files
+	resp.Ffree = statfs.Ffree
+	resp.Bsize = uint32(statfs.Bsize)
+	resp.Namelen = uint32(statfs.Namelen)
+	resp.Frsize = uint32(statfs.Frsize)
+
+	return nil
+}

--- a/fuse/statfs_darwin.go
+++ b/fuse/statfs_darwin.go
@@ -1,0 +1,35 @@
+package fuse
+
+import (
+	"context"
+	"syscall"
+
+	"bazil.org/fuse"
+)
+
+// Statfs is a passthrough to the underlying file system.
+func (fsys *FileSystem) Statfs(ctx context.Context, req *fuse.StatfsRequest, resp *fuse.StatfsResponse) error {
+	// Obtain statfs() call from underlying store path.
+	var statfs syscall.Statfs_t
+	path := fsys.store.Path()
+	if err := syscall.Statfs(path, &statfs); err != nil {
+		return err
+	}
+
+	// Copy stats over from the underlying file system to the response.
+	resp.Blocks = statfs.Blocks
+	resp.Bfree = statfs.Bfree
+	resp.Bavail = statfs.Bavail
+	resp.Files = statfs.Files
+	resp.Ffree = statfs.Ffree
+	resp.Bsize = uint32(statfs.Bsize)
+	// This should be available via pathconf(_, _PC_PATH_MAX), but isn't exposed nicely in Go.
+	resp.Namelen = 1024
+	// I can't find where this is exposed on MacOS. It should be 512, 1024 or 4096 (recent
+	// MacBooks?). I'm guessing the hardware-level capability is intended, not the filesystem-level
+	// choice. The block size seems to match for now.
+	// https://stackoverflow.com/questions/61391135/get-block-file-size-on-macos-with-statfs
+	resp.Frsize = statfs.Bsize
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.12
 	github.com/prometheus/client_golang v1.13.0
 	github.com/superfly/ltx v0.2.3
+	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -40,7 +41,6 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
-	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
 	golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
@@ -49,3 +49,5 @@ require (
 replace github.com/mattn/go-sqlite3 => github.com/benbjohnson/go-sqlite3 v0.0.0-20220723145740-eed275a583e0
 
 // replace github.com/superfly/ltx => ../ltx
+
+replace bazil.org/fuse => github.com/zegl/fuse v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05 h1:UrYe9YkT4Wpm6D+zByEyCJQzDqTPXqTDUI7bZ41i9VE=
-bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05/go.mod h1:h0h5FBYpXThbvSfTqthw+0I4nmHnhTHkO5BoOHsBWqg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -315,6 +313,8 @@ github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/zegl/fuse v0.1.1 h1:K3i5a9sJlIJ3IVRPQm6Mq2Sv9ohhShFspMYnVg+xk3Y=
+github.com/zegl/fuse v0.1.1/go.mod h1:mhYJQMyOpy5QASAX/oWAlElyUgEILg3sKd67TcgginU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -392,7 +392,6 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220909164309-bea034e7d591 h1:D0B/7al0LLrVC8aWF4+oxpv/m8bc7ViFfVS8/gXGdqI=
 golang.org/x/net v0.0.0-20220909164309-bea034e7d591/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=


### PR DESCRIPTION
This fixes builds and works on MacOS.

github.com/zegl/fuse fixes the fact that bazil.org/fuse dropped support for MacOS. It works with both Linux and MacOS I use it for both in production for another project. I have a downstream of this, https://github.com/anacrolix/fuse that I use to avoid a replace directive if that's preferable. (Replace directives break out of tree installations, like `go install github.com/superfly/litefs/cmd/litefs@latest` right now).

MAX_PATH_LEN doesn't seem to be exposed anywhere nicely in Darwin in Go. CGO might be the only way to get that, but I'm pretty sure it's hardcoded to 1024 universally for Darwin. I'm not completely sure about the fragment size, I am able show that MacBook SSDs are using 4096, but smaller values exist for other storage devices. I picked 512 for now which works on the external hard disk I'm testing with.