### PR TITLE
Fix return lock type for SHM lock

### DIFF
--- a/fuse/database_node.go
+++ b/fuse/database_node.go
@@ -172,7 +172,8 @@ func (n *DatabaseNode) canLock(owner fuse.LockOwner, typ fuse.LockType, lockType
 	case fuse.LockRead:
 		return guard.CanRLock()
 	case fuse.LockWrite:
-		return guard.CanLock()
+		v, _ := guard.CanLock()
+		return v
 	default:
 		panic("fuse.DatabaseNode.canLock(): invalid POSIX lock type")
 	}

--- a/fuse/wal_node.go
+++ b/fuse/wal_node.go
@@ -167,7 +167,8 @@ func (n *WALNode) canLock(owner fuse.LockOwner, typ fuse.LockType, lockType lite
 	case fuse.LockRead:
 		return guard.CanRLock()
 	case fuse.LockWrite:
-		return guard.CanLock()
+		v, _ := guard.CanLock()
+		return v
 	default:
 		panic("fuse.WALNode.canLock(): invalid POSIX lock type")
 	}

--- a/rwmutex_test.go
+++ b/rwmutex_test.go
@@ -122,34 +122,44 @@ func TestRWMutexGuard_Lock(t *testing.T) {
 func TestRWMutexGuard_CanLock(t *testing.T) {
 	t.Run("WithExclusiveLock", func(t *testing.T) {
 		var mu litefs.RWMutex
-		if guard := mu.Guard(); !guard.CanLock() {
+		guard0 := mu.Guard()
+		if canLock, _ := guard0.CanLock(); !canLock {
 			t.Fatal("expected to be able to lock")
 		}
 		g := mu.Guard()
 		g.TryLock()
-		if guard := mu.Guard(); guard.CanLock() {
+		guard1 := mu.Guard()
+		if canLock, mutexState := guard1.CanLock(); canLock {
 			t.Fatal("expected to not be able to lock")
+		} else if got, want := mutexState, litefs.RWMutexStateExclusive; got != want {
+			t.Fatalf("mutex=%s, expected %s", got, want)
 		}
 		g.Unlock()
 
-		if guard := mu.Guard(); !guard.CanLock() {
+		guard2 := mu.Guard()
+		if canLock, _ := guard2.CanLock(); !canLock {
 			t.Fatal("expected to be able to lock again")
 		}
 	})
 
 	t.Run("WithSharedLock", func(t *testing.T) {
 		var mu litefs.RWMutex
-		if guard := mu.Guard(); !guard.CanLock() {
+		guard0 := mu.Guard()
+		if canLock, _ := guard0.CanLock(); !canLock {
 			t.Fatal("expected to be able to lock")
 		}
 		g := mu.Guard()
 		g.TryRLock()
-		if guard := mu.Guard(); guard.CanLock() {
+		guard1 := mu.Guard()
+		if canLock, mutexState := guard1.CanLock(); canLock {
 			t.Fatal("expected to not be able to lock")
+		} else if got, want := mutexState, litefs.RWMutexStateShared; got != want {
+			t.Fatalf("mutex=%s, want %s", got, want)
 		}
 		g.Unlock()
 
-		if guard := mu.Guard(); !guard.CanLock() {
+		guard2 := mu.Guard()
+		if canLock, _ := guard2.CanLock(); !canLock {
 			t.Fatal("expected to be able to lock again")
 		}
 	})


### PR DESCRIPTION
This PR fixes a bug in multi-process usage of SQLite when in WAL mode. Previously, running a read query while another process was open on the database would result in a `SQLITE_PROTOCOL` error. This was caused because LiteFS was not correctly setting the state of the blocking lock when `SHMNode.QueryLock()` was executed. Previously it was always returning `fuse.LockWrite` but SQLite needs to distinguish between a blocking read & write on the `UNIX_SHM_DMS` lock byte. SQLite executes a spin lock while this lock byte is under write lock and exit if it is has a read lock. Since it never showed the demotion of the write lock state to read lock state, this spin lock would eventually fail.