### PR TITLE
List journal filenames in root handle

### DIFF
--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -247,12 +247,22 @@ func TestFileSystem_ReadDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var want string
+	switch testingutil.JournalMode() {
+	case "wal":
+		want = "db0\ndb0-shm\ndb0-wal\ndb1\ndb1-shm\ndb1-wal\n"
+	case "persist", "truncate":
+		want = "db0\ndb0-journal\ndb1\ndb1-journal\n"
+	default:
+		want = "db0\ndb1\n"
+	}
+
 	// Read directory listing from mount.
 	cmd := exec.Command("ls")
 	cmd.Dir = fs.Path()
 	if buf, err := cmd.CombinedOutput(); err != nil {
 		t.Fatal(err)
-	} else if got, want := string(buf), "db0\ndb1\n"; got != want {
+	} else if got := string(buf); got != want {
 		t.Fatalf("unexpected output: %q", got)
 	}
 }

--- a/fuse/root_node.go
+++ b/fuse/root_node.go
@@ -2,6 +2,7 @@ package fuse
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"sort"
@@ -344,6 +345,25 @@ func (h *RootHandle) ReadDirAll(ctx context.Context) (ents []fuse.Dirent, err er
 			Name: db.Name(),
 			Type: fuse.DT_File,
 		})
+
+		if _, err := os.Stat(db.WALPath()); err == nil {
+			ents = append(ents, fuse.Dirent{
+				Name: fmt.Sprintf("%s-wal", db.Name()),
+				Type: fuse.DT_File,
+			})
+		}
+		if _, err := os.Stat(db.SHMPath()); err == nil {
+			ents = append(ents, fuse.Dirent{
+				Name: fmt.Sprintf("%s-shm", db.Name()),
+				Type: fuse.DT_File,
+			})
+		}
+		if _, err := os.Stat(db.JournalPath()); err == nil {
+			ents = append(ents, fuse.Dirent{
+				Name: fmt.Sprintf("%s-journal", db.Name()),
+				Type: fuse.DT_File,
+			})
+		}
 	}
 
 	return ents, nil

--- a/internal/testingutil/testingutil.go
+++ b/internal/testingutil/testingutil.go
@@ -13,13 +13,16 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-var (
-	journalMode = flag.String("journal-mode", "delete", "")
-)
+var journalMode = flag.String("journal-mode", "delete", "")
 
 // IsWALMode returns the true if -journal-mode is set to "wal".
 func IsWALMode() bool {
-	return strings.ToLower(*journalMode) == "wal"
+	return JournalMode() == "wal"
+}
+
+// JournalMode returns the value of -journal-mode.
+func JournalMode() string {
+	return strings.ToLower(*journalMode)
 }
 
 // OpenSQLDB opens a connection to a SQLite database.


### PR DESCRIPTION
Attempt to fix #124

After creating a db and set WAL journal mode, the mounted dir listing is:

```
$ ls dbs/ -lh
total 0
-rw-rw-rw- 1 daniel daniel 4.0K Oct 19 19:36 state.db
-rw-rw-rw- 1 daniel daniel  32K Oct 19 19:36 state.db-shm
-rw-rw-rw- 1 daniel daniel  37K Oct 19 19:36 state.db-wal
```

Passes tests:
```
$ go test -p 1 -timeout 5m ./fuse -journal-mode wal
ok      github.com/superfly/litefs/fuse 1.707s
$ go test -p 1 -timeout 5m ./fuse -journal-mode delete
ok      github.com/superfly/litefs/fuse 1.577s
```