### PR TITLE
Updates workflows to support external PRs

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -2,6 +2,9 @@ on:
   release:
     types:
       - published
+  push:
+    branches:
+      - main
   pull_request:
     types:
       - opened
@@ -10,7 +13,7 @@ on:
     branches-ignore:
       - "dependabot/**"
 
-name: "Pull Request"
+name: "Docker Image"
 jobs:
   docker:
     name: "Publish to Docker"
@@ -21,16 +24,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
-
-      - uses: docker/login-action@v1
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
         with:
           username: benbjohnson
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: flyio/litefs
           tags: |
@@ -41,7 +43,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         with:
           context: .
           push: true

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -27,8 +27,12 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - uses: docker/login-action@v2
+        id: login
+        env:
+          token_is_present: "${{ secrets.DOCKERHUB_TOKEN && true }}"
+        if: ${{ env.token_is_present }}
         with:
-          username: benbjohnson
+          username: ${{ secrets.DOCKERHUB_USERNAME || 'benbjohnson' }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - id: meta
@@ -46,7 +50,7 @@ jobs:
       - uses: docker/build-push-action@v3
         with:
           context: .
-          push: true
+          push: ${{ steps.login.outcome != 'skipped' }}
           platforms: ${{ env.PLATFORMS }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ jobs:
       VERSION: "${{ github.event_name == 'release' && github.event.release.name || github.sha }}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,13 @@
 name: "Push"
-on: ["push"]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   build:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,20 +6,15 @@ jobs:
     name: "Build"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: apt install
         run: sudo apt install -y fuse libfuse-dev libsqlite3-dev
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ inputs.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ inputs.os }}-go-
 
       - name: Build binary
         run: go install ./cmd/litefs
@@ -31,23 +26,18 @@ jobs:
       matrix:
         journal_mode: [delete, wal]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: apt install
         run: sudo apt install -y fuse libfuse-dev libsqlite3-dev consul
 
       - name: check fuse version
         run: fusermount -V
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ inputs.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ inputs.os }}-go-
 
       - name: Run unit tests
         run: go test -v .
@@ -72,18 +62,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: apt install
         run: sudo apt install -y fuse libfuse-dev libsqlite3-dev consul
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ inputs.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ inputs.os }}-go-
 
       - name: Start consul in dev mode
         run: consul agent -dev &
@@ -96,17 +81,12 @@ jobs:
     name: "Staticcheck"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ inputs.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ inputs.os }}-go-
+          go-version-file: 'go.mod'
+          cache: true
 
       - uses: dominikh/staticcheck-action@v1.2.0
         with:
@@ -116,17 +96,11 @@ jobs:
     name: "Errcheck"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ inputs.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ inputs.os }}-go-
+          go-version-file: 'go.mod'
 
       - run: go install github.com/kisielk/errcheck@latest
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,7 +60,7 @@ jobs:
       matrix:
         journal_mode: [delete, wal]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-go@v3
         with:
@@ -101,6 +101,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
+          cache: true
 
       - run: go install github.com/kisielk/errcheck@latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,11 @@ jobs:
       CC:     ${{ matrix.cc }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
+          cache: true
 
       - id: release
         uses: bruceadams/get-release@v1.2.3


### PR DESCRIPTION
A bunch of improvements:
* Run the test suite on external contributions (PRs)
* Build docker image but don't push it unless it is on main repo
* Build and push docker image for main branch
* Update action versions to latest releases
* Use integrated caching from actions/setup-go@v3
* Pull Go version from go.mod

In general this should make life easier to external contributors, while ensuring latest changes in main branch get an image pushed to docker hub.