### PR TITLE
Remove dead code for WAL locking

### DIFF
--- a/fuse/wal_node.go
+++ b/fuse/wal_node.go
@@ -2,11 +2,9 @@ package fuse
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log"
 	"os"
-	"sync"
 	"syscall"
 
 	"bazil.org/fuse"
@@ -28,17 +26,12 @@ var _ fs.NodePoller = (*WALNode)(nil)
 type WALNode struct {
 	fsys *FileSystem
 	db   *litefs.DB
-
-	mu        sync.Mutex
-	guardSets map[fuse.LockOwner]*litefs.WALGuardSet
 }
 
 func newWALNode(fsys *FileSystem, db *litefs.DB) *WALNode {
 	return &WALNode{
 		fsys: fsys,
 		db:   db,
-
-		guardSets: make(map[fuse.LockOwner]*litefs.WALGuardSet),
 	}
 }
 
@@ -92,113 +85,6 @@ func (n *WALNode) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
 	return nil
 }
 
-// lock tries to acquire a lock on a byte range of the node.
-// If a conflicting lock is already held, returns syscall.EAGAIN.
-func (n *WALNode) lock(ctx context.Context, req *fuse.LockRequest) error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	// Parse lock range and ensure we are only performing one lock at a time.
-	lockTypes := litefs.ParseWALLockRange(req.Lock.Start, req.Lock.End)
-	if len(lockTypes) == 0 {
-		return fmt.Errorf("no locks")
-	} else if len(lockTypes) > 1 {
-		return fmt.Errorf("cannot acquire multiple WAL locks at once")
-	}
-	lockType := lockTypes[0]
-
-	guard := n.guardSet(req.LockOwner).Guard(lockType)
-
-	switch typ := req.Lock.Type; typ {
-	case fuse.LockRead:
-		if !guard.TryRLock() {
-			return syscall.EAGAIN
-		}
-		return nil
-	case fuse.LockWrite:
-		if !guard.TryLock() {
-			return syscall.EAGAIN
-		}
-		return nil
-	default:
-		panic("fuse.WALNode.lock(): invalid POSIX lock type")
-	}
-}
-
-// Unlock releases the lock on a byte range of the node. Locks can
-// be released also implicitly, see HandleFlockLocker and HandlePOSIXLocker.
-func (n *WALNode) unlock(ctx context.Context, req *fuse.UnlockRequest) error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	for _, lockType := range litefs.ParseWALLockRange(req.Lock.Start, req.Lock.End) {
-		guard := n.guardSet(req.LockOwner).Guard(lockType)
-		guard.Unlock()
-	}
-	return nil
-}
-
-// QueryLock returns the current state of locks held for the byte range of the node.
-func (n *WALNode) queryLock(ctx context.Context, req *fuse.QueryLockRequest, resp *fuse.QueryLockResponse) error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	for _, lockType := range litefs.ParseWALLockRange(req.Lock.Start, req.Lock.End) {
-		if !n.canLock(req.LockOwner, req.Lock.Type, lockType) {
-			resp.Lock = fuse.FileLock{
-				Start: req.Lock.Start,
-				End:   req.Lock.End,
-				Type:  fuse.LockWrite,
-				PID:   -1,
-			}
-			return nil
-		}
-	}
-	return nil
-}
-
-// canLock returns true if the given lock can be acquired.
-func (n *WALNode) canLock(owner fuse.LockOwner, typ fuse.LockType, lockType litefs.WALLockType) bool {
-	guard := n.guardSet(owner).Guard(lockType)
-
-	switch typ {
-	case fuse.LockUnlock:
-		return true
-	case fuse.LockRead:
-		return guard.CanRLock()
-	case fuse.LockWrite:
-		v, _ := guard.CanLock()
-		return v
-	default:
-		panic("fuse.WALNode.canLock(): invalid POSIX lock type")
-	}
-}
-
-func (n *WALNode) guardSet(owner fuse.LockOwner) *litefs.WALGuardSet {
-	gs := n.guardSets[owner]
-	if gs == nil {
-		gs = n.db.WALGuardSet()
-		n.guardSets[owner] = gs
-	}
-	return gs
-}
-
-// flush handles a handle flush request.
-func (n *WALNode) flush(ctx context.Context, req *fuse.FlushRequest) error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	guardSet := n.guardSets[req.LockOwner]
-	if guardSet == nil {
-		return nil
-	}
-
-	guardSet.Unlock()
-	delete(n.guardSets, req.LockOwner)
-
-	return nil
-}
-
 func (n *WALNode) Forget() { n.fsys.root.ForgetNode(n) }
 
 // ENOSYS is a special return code for xattr requests that will be treated as a permanent failure for any such
@@ -228,7 +114,6 @@ func (n *WALNode) Poll(ctx context.Context, req *fuse.PollRequest, resp *fuse.Po
 var _ fs.Handle = (*WALHandle)(nil)
 var _ fs.HandleReader = (*WALHandle)(nil)
 var _ fs.HandleWriter = (*WALHandle)(nil)
-var _ fs.HandlePOSIXLocker = (*WALHandle)(nil)
 
 // WALHandle represents a file handle to a SQLite WAL file.
 type WALHandle struct {
@@ -260,26 +145,6 @@ func (h *WALHandle) Write(ctx context.Context, req *fuse.WriteRequest, resp *fus
 	return nil
 }
 
-func (h *WALHandle) Flush(ctx context.Context, req *fuse.FlushRequest) error {
-	return h.node.flush(ctx, req)
-}
-
 func (h *WALHandle) Release(ctx context.Context, req *fuse.ReleaseRequest) error {
 	return h.file.Close()
-}
-
-func (h *WALHandle) Lock(ctx context.Context, req *fuse.LockRequest) error {
-	return h.node.lock(ctx, req)
-}
-
-func (h *WALHandle) LockWait(ctx context.Context, req *fuse.LockWaitRequest) error {
-	return fuse.Errno(syscall.ENOSYS)
-}
-
-func (h *WALHandle) Unlock(ctx context.Context, req *fuse.UnlockRequest) error {
-	return h.node.unlock(ctx, req)
-}
-
-func (h *WALHandle) QueryLock(ctx context.Context, req *fuse.QueryLockRequest, resp *fuse.QueryLockResponse) error {
-	return h.node.queryLock(ctx, req, resp)
 }


### PR DESCRIPTION
This code was copied over to SHM (where it belongs) but was not deleted from the WAL node.