### PR TITLE
Consolidate locks & guards

### DIFF
--- a/fuse/database_node.go
+++ b/fuse/database_node.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"sync"
 	"syscall"
 
 	"bazil.org/fuse"
@@ -28,17 +27,12 @@ var _ fs.NodePoller = (*DatabaseNode)(nil)
 type DatabaseNode struct {
 	fsys *FileSystem
 	db   *litefs.DB
-
-	mu        sync.Mutex
-	guardSets map[fuse.LockOwner]*litefs.DatabaseGuardSet
 }
 
 func newDatabaseNode(fsys *FileSystem, db *litefs.DB) *DatabaseNode {
 	return &DatabaseNode{
 		fsys: fsys,
 		db:   db,
-
-		guardSets: make(map[fuse.LockOwner]*litefs.DatabaseGuardSet),
 	}
 }
 
@@ -94,113 +88,6 @@ func (n *DatabaseNode) Fsync(ctx context.Context, req *fuse.FsyncRequest) error 
 	}
 
 	// TODO: fsync parent directory
-	return nil
-}
-
-// lock tries to acquire a lock on a byte range of the node.
-// If a conflicting lock is already held, returns syscall.EAGAIN.
-func (n *DatabaseNode) lock(ctx context.Context, req *fuse.LockRequest) error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	// Parse lock range and ensure we are only performing one lock at a time.
-	lockTypes := litefs.ParseDatabaseLockRange(req.Lock.Start, req.Lock.End)
-	if len(lockTypes) == 0 {
-		return fmt.Errorf("no database locks")
-	} else if len(lockTypes) > 1 {
-		return fmt.Errorf("cannot acquire multiple locks at once")
-	}
-	lockType := lockTypes[0]
-
-	guard := n.guardSet(req.LockOwner).Guard(lockType)
-
-	switch typ := req.Lock.Type; typ {
-	case fuse.LockRead:
-		if !guard.TryRLock() {
-			return syscall.EAGAIN
-		}
-		return nil
-	case fuse.LockWrite:
-		if !guard.TryLock() {
-			return syscall.EAGAIN
-		}
-		return nil
-	default:
-		panic("fuse.DatabaseNode.lock(): invalid POSIX lock type")
-	}
-}
-
-// Unlock releases the lock on a byte range of the node. Locks can
-// be released also implicitly, see HandleFlockLocker and HandlePOSIXLocker.
-func (n *DatabaseNode) unlock(ctx context.Context, req *fuse.UnlockRequest) error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	for _, lockType := range litefs.ParseDatabaseLockRange(req.Lock.Start, req.Lock.End) {
-		guard := n.guardSet(req.LockOwner).Guard(lockType)
-		guard.Unlock()
-	}
-	return nil
-}
-
-// QueryLock returns the current state of locks held for the byte range of the node.
-func (n *DatabaseNode) queryLock(ctx context.Context, req *fuse.QueryLockRequest, resp *fuse.QueryLockResponse) error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	for _, lockType := range litefs.ParseDatabaseLockRange(req.Lock.Start, req.Lock.End) {
-		if !n.canLock(req.LockOwner, req.Lock.Type, lockType) {
-			resp.Lock = fuse.FileLock{
-				Start: req.Lock.Start,
-				End:   req.Lock.End,
-				Type:  fuse.LockWrite,
-				PID:   -1,
-			}
-			return nil
-		}
-	}
-	return nil
-}
-
-// canLock returns true if the given lock can be acquired.
-func (n *DatabaseNode) canLock(owner fuse.LockOwner, typ fuse.LockType, lockType litefs.DatabaseLockType) bool {
-	guard := n.guardSet(owner).Guard(lockType)
-
-	switch typ {
-	case fuse.LockUnlock:
-		return true
-	case fuse.LockRead:
-		return guard.CanRLock()
-	case fuse.LockWrite:
-		v, _ := guard.CanLock()
-		return v
-	default:
-		panic("fuse.DatabaseNode.canLock(): invalid POSIX lock type")
-	}
-}
-
-func (n *DatabaseNode) guardSet(owner fuse.LockOwner) *litefs.DatabaseGuardSet {
-	gs := n.guardSets[owner]
-	if gs == nil {
-		gs = n.db.DatabaseGuardSet()
-		n.guardSets[owner] = gs
-	}
-	return gs
-}
-
-// flush handles a handle flush request.
-func (n *DatabaseNode) flush(ctx context.Context, req *fuse.FlushRequest) error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	guardSet := n.guardSets[req.LockOwner]
-	if guardSet == nil {
-		return nil
-	}
-
-	guardSet.Unlock()
-	delete(n.guardSets, req.LockOwner)
-
 	return nil
 }
 
@@ -265,7 +152,10 @@ func (h *DatabaseHandle) Write(ctx context.Context, req *fuse.WriteRequest, resp
 }
 
 func (h *DatabaseHandle) Flush(ctx context.Context, req *fuse.FlushRequest) error {
-	return h.node.flush(ctx, req)
+	if gs := h.node.fsys.GuardSet(h.node.db, req.LockOwner); gs != nil {
+		gs.UnlockDatabase()
+	}
+	return nil
 }
 
 func (h *DatabaseHandle) Release(ctx context.Context, req *fuse.ReleaseRequest) error {
@@ -273,7 +163,31 @@ func (h *DatabaseHandle) Release(ctx context.Context, req *fuse.ReleaseRequest) 
 }
 
 func (h *DatabaseHandle) Lock(ctx context.Context, req *fuse.LockRequest) error {
-	return h.node.lock(ctx, req)
+	// Parse lock range and ensure we are only performing one lock at a time.
+	lockTypes := litefs.ParseDatabaseLockRange(req.Lock.Start, req.Lock.End)
+	if len(lockTypes) == 0 {
+		return fmt.Errorf("no database locks")
+	} else if len(lockTypes) > 1 {
+		return fmt.Errorf("cannot acquire multiple locks at once")
+	}
+	lockType := lockTypes[0]
+
+	guard := h.node.fsys.CreateGuardSetIfNotExists(h.node.db, req.LockOwner).Guard(lockType)
+
+	switch typ := req.Lock.Type; typ {
+	case fuse.LockRead:
+		if !guard.TryRLock() {
+			return syscall.EAGAIN
+		}
+		return nil
+	case fuse.LockWrite:
+		if !guard.TryLock() {
+			return syscall.EAGAIN
+		}
+		return nil
+	default:
+		panic("fuse.DatabaseNode.lock(): invalid POSIX lock type")
+	}
 }
 
 func (h *DatabaseHandle) LockWait(ctx context.Context, req *fuse.LockWaitRequest) error {
@@ -281,9 +195,40 @@ func (h *DatabaseHandle) LockWait(ctx context.Context, req *fuse.LockWaitRequest
 }
 
 func (h *DatabaseHandle) Unlock(ctx context.Context, req *fuse.UnlockRequest) error {
-	return h.node.unlock(ctx, req)
+	for _, lockType := range litefs.ParseDatabaseLockRange(req.Lock.Start, req.Lock.End) {
+		if gs := h.node.fsys.GuardSet(h.node.db, req.LockOwner); gs != nil {
+			gs.Guard(lockType).Unlock()
+		}
+	}
+	return nil
 }
 
 func (h *DatabaseHandle) QueryLock(ctx context.Context, req *fuse.QueryLockRequest, resp *fuse.QueryLockResponse) error {
-	return h.node.queryLock(ctx, req, resp)
+	for _, lockType := range litefs.ParseDatabaseLockRange(req.Lock.Start, req.Lock.End) {
+		if !h.canLock(req.LockOwner, req.Lock.Type, lockType) {
+			resp.Lock = fuse.FileLock{
+				Start: req.Lock.Start,
+				End:   req.Lock.End,
+				Type:  fuse.LockWrite,
+				PID:   -1,
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+func (h *DatabaseHandle) canLock(owner fuse.LockOwner, typ fuse.LockType, lockType litefs.LockType) bool {
+	guard := h.node.fsys.CreateGuardSetIfNotExists(h.node.db, owner).Guard(lockType)
+	switch typ {
+	case fuse.LockUnlock:
+		return true
+	case fuse.LockRead:
+		return guard.CanRLock()
+	case fuse.LockWrite:
+		v, _ := guard.CanLock()
+		return v
+	default:
+		panic("fuse.DatabaseHandle.canLock(): invalid POSIX lock type")
+	}
 }

--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"sync"
 	"syscall"
 
 	"bazil.org/fuse"
@@ -17,13 +18,16 @@ var _ litefs.Invalidator = (*FileSystem)(nil)
 
 // FileSystem represents a raw interface to the FUSE file system.
 type FileSystem struct {
-	path string // mount path
+	mu sync.Mutex
 
+	path  string // mount path
 	store *litefs.Store
 
 	conn   *fuse.Conn
 	server *fs.Server
 	root   *RootNode
+
+	guardSets map[fuse.LockOwner]*litefs.GuardSet
 
 	// User & Group ID for all files in the filesystem.
 	Uid int
@@ -38,6 +42,8 @@ func NewFileSystem(path string, store *litefs.Store) *FileSystem {
 	fsys := &FileSystem{
 		path:  path,
 		store: store,
+
+		guardSets: make(map[fuse.LockOwner]*litefs.GuardSet),
 
 		Uid: os.Getuid(),
 		Gid: os.Getgid(),
@@ -93,6 +99,33 @@ func (fsys *FileSystem) Unmount() (err error) {
 // Root returns the root directory in the file system.
 func (fsys *FileSystem) Root() (fs.Node, error) {
 	return fsys.root, nil
+}
+
+// GuardSet returns a database guard set for the given owner.
+func (fsys *FileSystem) GuardSet(db *litefs.DB, owner fuse.LockOwner) *litefs.GuardSet {
+	fsys.mu.Lock()
+	defer fsys.mu.Unlock()
+
+	gs := fsys.guardSets[owner]
+	if gs == nil {
+		gs = db.GuardSet()
+		fsys.guardSets[owner] = gs
+	}
+	return gs
+}
+
+// CreateGuardSetIfNotExists returns a database guard set for the given owner.
+// Creates a new guard set if one is not associated with the owner.
+func (fsys *FileSystem) CreateGuardSetIfNotExists(db *litefs.DB, owner fuse.LockOwner) *litefs.GuardSet {
+	fsys.mu.Lock()
+	defer fsys.mu.Unlock()
+
+	gs := fsys.guardSets[owner]
+	if gs == nil {
+		gs = db.GuardSet()
+		fsys.guardSets[owner] = gs
+	}
+	return gs
 }
 
 // Statfs is a passthrough to the underlying file system.


### PR DESCRIPTION
This pull request consolidates the `DatabaseGuardSet` & `WALGuardSet` into a single set of guards for the database. Database & SHM files can use the `UnlockDatabase()` and `UnlockSHM()` methods, respectively, to unlock the correct locks on flush.