### PR TITLE
Fix snapshot in WAL mode

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -255,7 +255,7 @@ func (s *Server) streamDB(ctx context.Context, w http.ResponseWriter, name strin
 
 		newPos, err := s.streamLTX(ctx, w, db, clientPos.TXID+1)
 		if err != nil {
-			return fmt.Errorf("stream ltx: pos=%d", clientPos.TXID)
+			return fmt.Errorf("stream ltx (tx %d): %w", clientPos.TXID, err)
 		}
 		posMap[name] = newPos
 	}


### PR DESCRIPTION
This pull request fixes the `DB.WriteSnapshotTo()` method to include the latest pages from the WAL file for the current position. Previously, this method only copied the database file which didn't include up-to-date pages.

Fixes #128 