### PR TITLE
Reduce logging

### DIFF
--- a/db.go
+++ b/db.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -1309,7 +1308,6 @@ func (db *DB) EnforceRetention(ctx context.Context, minTime time.Time) error {
 
 		// Remove file if it passes all the checks.
 		filename := filepath.Join(db.LTXDir(), ent.Name())
-		log.Printf("removing ltx file, per retention: db=%s file=%s", db.Name(), ent.Name())
 		if err := os.Remove(filename); err != nil {
 			return err
 		}

--- a/http/server.go
+++ b/http/server.go
@@ -283,13 +283,10 @@ func (s *Server) streamLTX(ctx context.Context, w http.ResponseWriter, db *litef
 	}
 
 	// Write LTX file.
-	n, err := io.Copy(w, r)
-	if err != nil {
+	if _, err := io.Copy(w, r); err != nil {
 		return litefs.Pos{}, fmt.Errorf("write ltx file: %w", err)
 	}
 	w.(http.Flusher).Flush()
-
-	log.Printf("send frame<ltx>: db=%q tx=%s-%s size=%d", db.Name(), ltx.FormatTXID(r.Header().MinTXID), ltx.FormatTXID(r.Header().MaxTXID), n)
 
 	serverFrameSendCountMetricVec.WithLabelValues(db.Name(), "ltx")
 
@@ -308,10 +305,6 @@ func (s *Server) streamLTXSnapshot(ctx context.Context, w http.ResponseWriter, d
 		return litefs.Pos{}, fmt.Errorf("write ltx snapshot file: %w", err)
 	}
 	w.(http.Flusher).Flush()
-
-	log.Printf("send frame<ltx>: db=%q tx=(%s,%s) chksum=(%x,%x) (snapshot)",
-		db.Name(), ltx.FormatTXID(header.MinTXID), ltx.FormatTXID(header.MaxTXID),
-		header.PreApplyChecksum, trailer.PostApplyChecksum)
 
 	serverFrameSendCountMetricVec.WithLabelValues(db.Name(), "ltx:snapshot")
 

--- a/store.go
+++ b/store.go
@@ -691,8 +691,6 @@ func (s *Store) processLTXStreamFrame(ctx context.Context, frame *LTXStreamFrame
 		return fmt.Errorf("sync ltx dir: %w", err)
 	}
 
-	log.Printf("recv frame<ltx>: db=%q tx=%s-%s size=%d", db.Name(), ltx.FormatTXID(r.Header().MinTXID), ltx.FormatTXID(r.Header().MaxTXID), n)
-
 	// Update metrics
 	dbLTXCountMetricVec.WithLabelValues(db.Name()).Inc()
 	dbLTXBytesMetricVec.WithLabelValues(db.Name()).Set(float64(n))


### PR DESCRIPTION
This pull request removes the `send frame`, `recv frame` and retention log lines as they were excessive under load. Periodic summary logging (e.g. every 10s) can be added in the future if it's helpful.

Fixes https://github.com/superfly/litefs/issues/141