### PR TITLE
refactor: replace `Readdir(-1)` with `os.ReadDir`

### DIFF
--- a/db.go
+++ b/db.go
@@ -390,13 +390,7 @@ func (db *DB) readWALPageOffsets(f *os.File) (_ map[uint32]int64, lastCommit uin
 }
 
 func (db *DB) recoverFromLTX() error {
-	f, err := os.Open(db.LTXDir())
-	if err != nil {
-		return fmt.Errorf("open ltx dir: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	fis, err := f.Readdir(-1)
+	fis, err := os.ReadDir(db.LTXDir())
 	if err != nil {
 		return fmt.Errorf("readdir: %w", err)
 	}

--- a/store.go
+++ b/store.go
@@ -181,13 +181,7 @@ func (s *Store) openDatabases() error {
 		return err
 	}
 
-	f, err := os.Open(s.DBDir())
-	if err != nil {
-		return fmt.Errorf("open databases dir: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	fis, err := f.Readdir(-1)
+	fis, err := os.ReadDir(s.DBDir())
 	if err != nil {
 		return fmt.Errorf("readdir: %w", err)
 	}
@@ -195,10 +189,6 @@ func (s *Store) openDatabases() error {
 		if err := s.openDatabase(fi.Name()); err != nil {
 			return fmt.Errorf("open database(%q): %w", fi.Name(), err)
 		}
-	}
-
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("close databases dir: %w", err)
 	}
 
 	// Update metrics.


### PR DESCRIPTION
The following code block
```go
	f, err := os.Open(dirname)
	if err != nil {
		return err
	}
	defer f.Close()

	fis, err := f.Readdir(-1)
```

can be replaced with just `os.ReadDir(dirname)`.