### PR TITLE
Retain OS page cache on open(2)

### DIFF
--- a/fuse/database_node.go
+++ b/fuse/database_node.go
@@ -67,6 +67,8 @@ func (n *DatabaseNode) Setattr(ctx context.Context, req *fuse.SetattrRequest, re
 }
 
 func (n *DatabaseNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
+	resp.Flags |= fuse.OpenKeepCache
+
 	f, err := os.OpenFile(n.db.DatabasePath(), os.O_RDWR, 0666)
 	if err != nil {
 		return nil, err

--- a/fuse/journal_node.go
+++ b/fuse/journal_node.go
@@ -47,6 +47,8 @@ func (n *JournalNode) Attr(ctx context.Context, attr *fuse.Attr) error {
 }
 
 func (n *JournalNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
+	resp.Flags |= fuse.OpenKeepCache
+
 	f, err := os.OpenFile(n.db.JournalPath(), os.O_RDWR, 0666)
 	if err != nil {
 		return nil, err

--- a/fuse/root_node.go
+++ b/fuse/root_node.go
@@ -148,6 +148,8 @@ func (n *RootNode) Create(ctx context.Context, req *fuse.CreateRequest, resp *fu
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
+	resp.Flags |= fuse.OpenKeepCache
+
 	dbName, fileType := ParseFilename(req.Name)
 
 	switch fileType {
@@ -248,6 +250,7 @@ func (n *RootNode) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
 }
 
 func (n *RootNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
+	resp.Flags |= fuse.OpenKeepCache
 	return NewRootHandle(n), nil
 }
 

--- a/fuse/shm_node.go
+++ b/fuse/shm_node.go
@@ -62,6 +62,8 @@ func (n *SHMNode) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *f
 }
 
 func (n *SHMNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
+	resp.Flags |= fuse.OpenKeepCache
+
 	f, err := os.OpenFile(n.db.SHMPath(), os.O_RDWR, 0666)
 	if err != nil {
 		return nil, err

--- a/fuse/wal_node.go
+++ b/fuse/wal_node.go
@@ -61,6 +61,8 @@ func (n *WALNode) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *f
 }
 
 func (n *WALNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
+	resp.Flags |= fuse.OpenKeepCache
+
 	f, err := os.OpenFile(n.db.WALPath(), os.O_RDWR, 0666)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This pull request adds the `fuse.OpenKeepCache` flag to `Open()` and `Create()` calls in the FUSE layer so that the OS page cache is preserved.