### PR TITLE
Attempt unmount for unclean exit

### DIFF
--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -62,6 +62,9 @@ func (fsys *FileSystem) Store() *litefs.Store { return fsys.store }
 
 // Mount mounts the file system to the mount point.
 func (fsys *FileSystem) Mount() (err error) {
+	// Attempt to unmount if it did not close cleanly before.
+	_ = fuse.Unmount(fsys.path)
+
 	// Ensure mount directory exists before trying to mount to it.
 	if err := os.MkdirAll(fsys.path, 0777); err != nil {
 		return err


### PR DESCRIPTION
This pull request adds a `fuse.Unmount()` before attempting to mount. This helps avoid needing the user to run `umount` if there was an unclean exit of `litefs`.