### PR TITLE
Add SHM locks to /debug/vars

### DIFF
--- a/db.go
+++ b/db.go
@@ -1409,9 +1409,21 @@ type dbVarJSON struct {
 	TXID     string `json:"txid"`
 	Checksum string `json:"checksum"`
 
-	PendingLock  string `json:"pendingLock"`
-	SharedLock   string `json:"sharedLock"`
-	ReservedLock string `json:"reservedLock"`
+	Locks struct {
+		Pending  string `json:"pending"`
+		Shared   string `json:"shared"`
+		Reserved string `json:"reserved"`
+
+		Write   string `json:"write"`
+		Ckpt    string `json:"ckpt"`
+		Recover string `json:"recover"`
+		Read0   string `json:"read0"`
+		Read1   string `json:"read1"`
+		Read2   string `json:"read2"`
+		Read3   string `json:"read3"`
+		Read4   string `json:"read4"`
+		DMS     string `json:"dms"`
+	} `json:"locks"`
 }
 
 func buildJournalPageMap(f *os.File) (map[uint32]uint64, error) {

--- a/store.go
+++ b/store.go
@@ -708,16 +708,28 @@ func (v *StoreVar) String() string {
 	for _, db := range s.DBs() {
 		pos := db.Pos()
 
-		m.DBs[db.Name()] = &dbVarJSON{
+		dbJSON := &dbVarJSON{
 			Name:     db.Name(),
 			PageSize: db.PageSize(),
 			TXID:     ltx.FormatTXID(pos.TXID),
 			Checksum: fmt.Sprintf("%016x", pos.PostApplyChecksum),
-
-			PendingLock:  db.pendingLock.State().String(),
-			SharedLock:   db.sharedLock.State().String(),
-			ReservedLock: db.reservedLock.State().String(),
 		}
+
+		dbJSON.Locks.Pending = db.pendingLock.State().String()
+		dbJSON.Locks.Shared = db.sharedLock.State().String()
+		dbJSON.Locks.Reserved = db.reservedLock.State().String()
+
+		dbJSON.Locks.Write = db.writeLock.State().String()
+		dbJSON.Locks.Ckpt = db.ckptLock.State().String()
+		dbJSON.Locks.Recover = db.recoverLock.State().String()
+		dbJSON.Locks.Read0 = db.read0Lock.State().String()
+		dbJSON.Locks.Read1 = db.read1Lock.State().String()
+		dbJSON.Locks.Read2 = db.read2Lock.State().String()
+		dbJSON.Locks.Read3 = db.read3Lock.State().String()
+		dbJSON.Locks.Read4 = db.read4Lock.State().String()
+		dbJSON.Locks.DMS = db.dmsLock.State().String()
+
+		m.DBs[db.Name()] = dbJSON
 	}
 
 	b, err := json.Marshal(m)


### PR DESCRIPTION
This PR fixes the `/debug/vars` output to include SHM locks. Previously, it only included the database locks (`PENDING`, `SHARED`, & `RESERVED`). This also moves the locks to a `locks` JSON map.