### PR TITLE
Add endpoint for dynamically setting debug logging

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -320,6 +320,7 @@ func (m *Main) initConsul(ctx context.Context) (err error) {
 
 func (m *Main) initStore(ctx context.Context) error {
 	m.Store = litefs.NewStore(m.Config.DataDir, m.Config.Candidate)
+	m.Store.Debug = m.Config.Debug
 	m.Store.StrictVerify = m.Config.StrictVerify
 	m.Store.RetentionDuration = m.Config.Retention.Duration
 	m.Store.RetentionMonitorInterval = m.Config.Retention.MonitorInterval
@@ -342,12 +343,6 @@ func (m *Main) openStore(ctx context.Context) error {
 func (m *Main) initFileSystem(ctx context.Context) error {
 	// Build the file system to interact with the store.
 	fsys := fuse.NewFileSystem(m.Config.MountDir, m.Store)
-
-	// Log the store information with each log message.
-	if m.Config.Debug {
-		fsys.Debug = fuse.Debug(m.Store)
-	}
-
 	if err := fsys.Mount(); err != nil {
 		return fmt.Errorf("cannot open file system: %s", err)
 	}

--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -47,6 +47,8 @@ func NewFileSystem(path string, store *litefs.Store) *FileSystem {
 
 		Uid: os.Getuid(),
 		Gid: os.Getgid(),
+
+		Debug: store.DebugFn,
 	}
 
 	fsys.root = newRootNode(fsys)
@@ -78,7 +80,13 @@ func (fsys *FileSystem) Mount() (err error) {
 		return err
 	}
 
-	config := fs.Config{Debug: fsys.Debug}
+	config := fs.Config{
+		Debug: func(msg any) {
+			if fn := fsys.Debug; fn != nil {
+				fn(msg)
+			}
+		},
+	}
 	fsys.server = fs.New(fsys.conn, &config)
 
 	go func() {

--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -551,6 +551,7 @@ func newFileSystem(tb testing.TB, path string, leaser litefs.Leaser) *fuse.FileS
 	tb.Helper()
 
 	store := litefs.NewStore(filepath.Join(path, "data"), true)
+	store.Debug = *debug
 	store.StrictVerify = true
 	store.Leaser = leaser
 	if err := store.Open(); err != nil {
@@ -558,9 +559,6 @@ func newFileSystem(tb testing.TB, path string, leaser litefs.Leaser) *fuse.FileS
 	}
 
 	fs := fuse.NewFileSystem(filepath.Join(path, "mnt"), store)
-	if *debug {
-		fs.Debug = fuse.Debug(store)
-	}
 
 	store.Invalidator = fs
 

--- a/fuse/fuse.go
+++ b/fuse/fuse.go
@@ -2,7 +2,6 @@ package fuse
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"syscall"
@@ -61,14 +60,3 @@ type Error struct {
 
 func (e *Error) Errno() fuse.Errno { return e.errno }
 func (e *Error) Error() string     { return e.err.Error() }
-
-// Debug returns a logging function for use with fuse.Options.Debug.
-func Debug(store *litefs.Store) func(any) {
-	return func(msg any) {
-		status := "r"
-		if store.IsPrimary() {
-			status = "p"
-		}
-		log.Printf("%s [%s]: %s", store.ID(), status, msg)
-	}
-}

--- a/http/server.go
+++ b/http/server.go
@@ -131,8 +131,13 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	if r.URL.Path == "/metrics" {
+
+	switch r.URL.Path {
+	case "/metrics":
 		s.promHandler.ServeHTTP(w, r)
+		return
+	case "/sys/debug":
+		s.handleSysDebug(w, r)
 		return
 	}
 
@@ -309,6 +314,21 @@ func (s *Server) streamLTXSnapshot(ctx context.Context, w http.ResponseWriter, d
 	serverFrameSendCountMetricVec.WithLabelValues(db.Name(), "ltx:snapshot")
 
 	return litefs.Pos{TXID: header.MaxTXID, PostApplyChecksum: trailer.PostApplyChecksum}, nil
+}
+
+func (s *Server) handleSysDebug(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		_, _ = fmt.Fprintln(w, s.store.Debug)
+	case "PUT":
+		s.store.Debug = true
+		_, _ = fmt.Fprintln(w, "debug logging enabled")
+	case "DELETE":
+		s.store.Debug = false
+		_, _ = fmt.Fprintln(w, "debug logging disabled")
+	default:
+		Error(w, r, fmt.Errorf("method not allowed"), http.StatusMethodNotAllowed)
+	}
 }
 
 func Error(w http.ResponseWriter, r *http.Request, err error, code int) {

--- a/store.go
+++ b/store.go
@@ -62,6 +62,9 @@ type Store struct {
 	// Callback to notify kernel of file changes.
 	Invalidator Invalidator
 
+	// If true, enables debug logging.
+	Debug bool
+
 	// If true, computes and verifies the checksum of the entire database
 	// after every transaction. Should only be used during testing.
 	StrictVerify bool
@@ -691,6 +694,19 @@ func (s *Store) processLTXStreamFrame(ctx context.Context, frame *LTXStreamFrame
 	}
 
 	return nil
+}
+
+// DebugFn is called by FUSE when debug logging is enabled.
+func (s *Store) DebugFn(msg any) {
+	if !s.Debug {
+		return
+	}
+
+	status := "r"
+	if s.IsPrimary() {
+		status = "p"
+	}
+	log.Printf("%s [%s]: %s", s.ID(), status, msg)
 }
 
 var _ expvar.Var = (*StoreVar)(nil)


### PR DESCRIPTION
This pull request adds a set of endpoints on `/sys/debug` to update whether "debug" FUSE logging is enabled:

```sh
# Check current logging state.
$ curl localhost:20202/sys/debug
```

```sh
# Enable debug logging
$ curl -X PUT localhost:20202/sys/debug
```

```sh
# Disable debug logging
$ curl -X DELETE localhost:20202/sys/debug
```