### PR TITLE
Fix recovery on replication position mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: default
 default:
 
-.PHONY: staticcheck
-staticcheck:
-	staticcheck
+.PHONY: check
+check:
+	errcheck ./...
+	staticcheck ./...

--- a/http/http.go
+++ b/http/http.go
@@ -32,6 +32,8 @@ func ReadPosMapFrom(r io.Reader) (map[string]litefs.Pos, error) {
 		var pos litefs.Pos
 		if err := binary.Read(r, binary.BigEndian, &pos.TXID); err != nil {
 			return nil, err
+		} else if err := binary.Read(r, binary.BigEndian, &pos.PostApplyChecksum); err != nil {
+			return nil, err
 		}
 		m[string(name)] = pos
 	}
@@ -68,6 +70,8 @@ func WritePosMapTo(w io.Writer, m map[string]litefs.Pos) error {
 		}
 
 		if err := binary.Write(w, binary.BigEndian, pos.TXID); err != nil {
+			return err
+		} else if err := binary.Write(w, binary.BigEndian, pos.PostApplyChecksum); err != nil {
 			return err
 		}
 	}

--- a/http/server.go
+++ b/http/server.go
@@ -253,12 +253,28 @@ func (s *Server) streamDB(ctx context.Context, w http.ResponseWriter, name strin
 		clientPos := posMap[name]
 		dbPos := db.Pos()
 
+		// Invalidate client position if we're beyond the primary's TXID.
+		// This can occur if an old primary has unreplicated transactions and
+		// then loses its primary status and reconnects. By invalidating, we
+		// will cause a snapshot to occur.
+		if clientPos.TXID > dbPos.TXID {
+			log.Printf("client transaction id (%s) exceeds primary transaction id (%s), resetting to snapshot", ltx.FormatTXID(clientPos.TXID), ltx.FormatTXID(dbPos.TXID))
+			clientPos = litefs.Pos{}
+		}
+
+		// Invalidate client position if the TXID matches but the checksum does not.
+		// This can also occur if an old primary has unreplicated transactions.
+		if clientPos.TXID == dbPos.TXID && clientPos.PostApplyChecksum != dbPos.PostApplyChecksum {
+			log.Printf("client transaction id (%s) caught up but checksum is mismatched (%016x <> %016x), resetting to snapshot", ltx.FormatTXID(clientPos.TXID), clientPos.PostApplyChecksum, dbPos.PostApplyChecksum)
+			clientPos = litefs.Pos{}
+		}
+
 		// Exit when client has caught up.
 		if clientPos.TXID >= dbPos.TXID {
 			return nil
 		}
 
-		newPos, err := s.streamLTX(ctx, w, db, clientPos.TXID+1)
+		newPos, err := s.streamLTX(ctx, w, db, clientPos.TXID+1, clientPos.PostApplyChecksum)
 		if err != nil {
 			return fmt.Errorf("stream ltx (tx %d): %w", clientPos.TXID, err)
 		}
@@ -266,10 +282,11 @@ func (s *Server) streamDB(ctx context.Context, w http.ResponseWriter, name strin
 	}
 }
 
-func (s *Server) streamLTX(ctx context.Context, w http.ResponseWriter, db *litefs.DB, txID uint64) (newPos litefs.Pos, err error) {
+func (s *Server) streamLTX(ctx context.Context, w http.ResponseWriter, db *litefs.DB, txID uint64, preApplyChecksum uint64) (newPos litefs.Pos, err error) {
 	// Open LTX file, read header.
 	f, err := db.OpenLTXFile(txID)
 	if os.IsNotExist(err) {
+		log.Printf("transaction file for txid %s no longer available, resetting to snapshot", ltx.FormatTXID(txID))
 		return s.streamLTXSnapshot(ctx, w, db)
 	} else if err != nil {
 		return litefs.Pos{}, fmt.Errorf("open ltx file: %w", err)
@@ -279,6 +296,12 @@ func (s *Server) streamLTX(ctx context.Context, w http.ResponseWriter, db *litef
 	r := ltx.NewReader(f)
 	if err := r.PeekHeader(); err != nil {
 		return litefs.Pos{}, fmt.Errorf("peek ltx header: %w", err)
+	}
+
+	// If previous checksum on client does not match, return snapshot instead.
+	if r.Header().PreApplyChecksum != preApplyChecksum {
+		log.Printf("client preapply checksum mismatch, resetting from txid %s to snapshot", ltx.FormatTXID(txID))
+		return s.streamLTXSnapshot(ctx, w, db)
 	}
 
 	// Write frame.

--- a/store.go
+++ b/store.go
@@ -639,13 +639,6 @@ func (s *Store) processLTXStreamFrame(ctx context.Context, frame *LTXStreamFrame
 		return fmt.Errorf("peek ltx header: %w", err)
 	}
 
-	// Exit if LTX file does already exists.
-	path := db.LTXPath(r.Header().MinTXID, r.Header().MaxTXID)
-	if _, err := os.Stat(path); err == nil {
-		log.Printf("ltx file already exists, skipping: %s", path)
-		return nil
-	}
-
 	// Verify LTX file pre-apply checksum matches the current database position
 	// unless this is a snapshot, which will overwrite all data.
 	if hdr := r.Header(); !hdr.IsSnapshot() {
@@ -661,6 +654,7 @@ func (s *Store) processLTXStreamFrame(ctx context.Context, frame *LTXStreamFrame
 	// TODO: Remove all LTX files if this is a snapshot.
 
 	// Write LTX file to a temporary file and we'll atomically rename later.
+	path := db.LTXPath(r.Header().MinTXID, r.Header().MaxTXID)
 	tmpPath := path + ".tmp"
 	defer func() { _ = os.Remove(tmpPath) }()
 


### PR DESCRIPTION
This pull request fixes recovery in 3 scenarios:

1. Client has same TXID, mismatched checksum
2. Client has higher TXID than server
3. Client's TXID is lower than server, but preapply checksum does not match

All these scenarios are caused by unreplicated transactions from an old primary that has lost its primary status and is reconnecting as a replica. Different scenarios are caused by the number of unreplicated transactions and the number of new transactions on the new primary. LiteFS currently only supports asynchronous replication so unreplicated transactions will be lost in the event of a primary change.