### PR TITLE
Remove pre-exec sleep

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -369,9 +369,6 @@ func (m *Main) execCmd(ctx context.Context) error {
 		return nil
 	}
 
-	// TODO: Wait for primary/replica connection.
-	time.Sleep(5 * time.Second)
-
 	// Execute subcommand process.
 	args, err := shellwords.Parse(m.Config.Exec)
 	if err != nil {


### PR DESCRIPTION
This pull request removes the sleep that occurs before executing the `exec` command. It should have been removed after the "ready state" was introduced in https://github.com/superfly/litefs/pull/100 but it was missed.