### PR TITLE
Initialize DB.mode on open

### DIFF
--- a/db.go
+++ b/db.go
@@ -229,6 +229,13 @@ func (db *DB) initFromDatabaseHeader() error {
 	db.pageSize = hdr.PageSize
 	db.pageN = hdr.PageN
 
+	// Initialize database mode.
+	if hdr.WriteVersion == 2 && hdr.ReadVersion == 2 {
+		db.mode = DBModeWAL
+	} else {
+		db.mode = DBModeRollback
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR fixes a bug where reopening a database would cause the `DB.mode` to be lost until another transaction occurred. During this time, locking was not done correctly and could result in a deadlock. Tested that this fix resolves the issue on a live cluster.