### PR TITLE
Show position file in readdir output

### DIFF
--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -315,11 +315,11 @@ func TestFileSystem_ReadDir(t *testing.T) {
 	var want string
 	switch testingutil.JournalMode() {
 	case "wal":
-		want = "db0\ndb0-shm\ndb0-wal\ndb1\ndb1-shm\ndb1-wal\n"
+		want = "db0\ndb0-pos\ndb0-shm\ndb0-wal\ndb1\ndb1-pos\ndb1-shm\ndb1-wal\n"
 	case "persist", "truncate":
-		want = "db0\ndb0-journal\ndb1\ndb1-journal\n"
+		want = "db0\ndb0-journal\ndb0-pos\ndb1\ndb1-journal\ndb1-pos\n"
 	default:
-		want = "db0\ndb1\n"
+		want = "db0\ndb0-pos\ndb1\ndb1-pos\n"
 	}
 
 	// Read directory listing from mount.

--- a/fuse/root_node.go
+++ b/fuse/root_node.go
@@ -349,9 +349,14 @@ func (h *RootHandle) ReadDirAll(ctx context.Context) (ents []fuse.Dirent, err er
 			Type: fuse.DT_File,
 		})
 
-		if _, err := os.Stat(db.WALPath()); err == nil {
+		ents = append(ents, fuse.Dirent{
+			Name: db.Name() + "-pos",
+			Type: fuse.DT_File,
+		})
+
+		if _, err := os.Stat(db.JournalPath()); err == nil {
 			ents = append(ents, fuse.Dirent{
-				Name: fmt.Sprintf("%s-wal", db.Name()),
+				Name: fmt.Sprintf("%s-journal", db.Name()),
 				Type: fuse.DT_File,
 			})
 		}
@@ -361,9 +366,9 @@ func (h *RootHandle) ReadDirAll(ctx context.Context) (ents []fuse.Dirent, err er
 				Type: fuse.DT_File,
 			})
 		}
-		if _, err := os.Stat(db.JournalPath()); err == nil {
+		if _, err := os.Stat(db.WALPath()); err == nil {
 			ents = append(ents, fuse.Dirent{
-				Name: fmt.Sprintf("%s-journal", db.Name()),
+				Name: fmt.Sprintf("%s-wal", db.Name()),
 				Type: fuse.DT_File,
 			})
 		}


### PR DESCRIPTION
Previously, I was concerned about there being too many extra files and it'd be confusing for users so I excluded the `-pos` file from the `readdir` output. However, it's more confusing if folks are looking for it and can't find it so I'm adding it back in.

Fixes https://github.com/superfly/litefs/issues/174