### PR TITLE
Reduce Consul lock delay

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -19,7 +19,7 @@ const (
 	DefaultSessionName = "litefs"
 	DefaultKey         = "litefs/primary"
 	DefaultTTL         = 10 * time.Second
-	DefaultLockDelay   = 5 * time.Second
+	DefaultLockDelay   = 1 * time.Second
 )
 
 // Leaser represents an API for obtaining a distributed lock on a single key.


### PR DESCRIPTION
Since LiteFS has a recovery mechanism for divergent primaries, this PR reduces the lock delay from 5 seconds to 1 second.