### PR TITLE
Fix FUSE connection close deadlock

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -106,6 +106,8 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	fmt.Println("litefs shut down complete")
 }
 
 // Main represents the command line program.

--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -104,9 +104,6 @@ func (fsys *FileSystem) Unmount() (err error) {
 		if e := fuse.Unmount(fsys.path); err == nil {
 			err = e
 		}
-		if e := fsys.conn.Close(); err == nil {
-			err = e
-		}
 		fsys.conn = nil
 	}
 	return err


### PR DESCRIPTION
There seems to be a deadlock on the `rio` lock used in `fuse.Conn.Close()` and `fuse.Conn.ReadRequest()`. If the connection is actively being read then it is unable to be closed. This prevents the LiteFS store from closing and releasing the primary lease. The Fly.io supervisor will then eventually hard kill the process which will then incur the Consul TTL which causes more downtime than it should.

This pull request simply removes the `fuse.Conn.Close()` as the connection will be closed by the process exit anyway.

Fixes https://github.com/superfly/litefs/issues/171