### PR TITLE
Add 'strict-verify' to YAML config

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -144,7 +144,7 @@ type Config struct {
 	Candidate    bool   `yaml:"candidate"`
 	Debug        bool   `yaml:"debug"`
 	ExitOnError  bool   `yaml:"exit-on-error"`
-	StrictVerify bool   `yaml:"-"`
+	StrictVerify bool   `yaml:"strict-verify"`
 
 	Retention RetentionConfig `yaml:"retention"`
 	HTTP      HTTPConfig      `yaml:"http"`


### PR DESCRIPTION
This adds the `strict-verify` flag to the YAML config. This is only meant to be used for testing & debugging as it's computationally expensive to run on anything but small databases. On every commit, it checksums the entire database and verifies that the checksum matches the `PostApplyChecksum` in the LTX transaction file.