### PR TITLE
Fix compilation on Darwin

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -101,20 +101,20 @@ func runMount(ctx context.Context, args []string) error {
 
 	// Wait for signal or subcommand exit to stop program.
 	select {
-	case <-c.execCh:
+	case <-c.ExecCh():
 		cancel()
 		fmt.Println("subprocess exited, litefs shutting down")
 
 	case sig := <-signalCh:
-		if c.cmd != nil {
+		if cmd := c.Cmd(); cmd != nil {
 			fmt.Println("sending signal to exec process")
-			if err := c.cmd.Process.Signal(sig); err != nil {
+			if err := cmd.Process.Signal(sig); err != nil {
 				fmt.Fprintln(os.Stderr, "cannot signal exec process:", err)
 				os.Exit(1)
 			}
 
 			fmt.Println("waiting for exec process to close")
-			if err := <-c.execCh; err != nil && !strings.HasPrefix(err.Error(), "signal:") {
+			if err := <-c.ExecCh(); err != nil && !strings.HasPrefix(err.Error(), "signal:") {
 				fmt.Fprintln(os.Stderr, "cannot wait for exec process:", err)
 				os.Exit(1)
 			}

--- a/cmd/litefs/mount_darwin.go
+++ b/cmd/litefs/mount_darwin.go
@@ -1,0 +1,40 @@
+// go:build darwin
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// MountCommand represents a command to mount the file system.
+type MountCommand struct {
+	Config Config
+}
+
+// NewMountCommand returns a new instance of MountCommand.
+func NewMountCommand() *MountCommand {
+	return &MountCommand{}
+}
+
+// Close closes the command.
+func (c *MountCommand) Close() error { return nil }
+
+// ExecCh always returns nil.
+func (c *MountCommand) ExecCh() chan error { return nil }
+
+// Cmd always returns nil.
+func (c *MountCommand) Cmd() *exec.Cmd { return nil }
+
+// ParseFlags returns an error for non-Linux systems.
+func (c *MountCommand) ParseFlags(ctx context.Context, args []string) error {
+	return fmt.Errorf("litefs-mount is not available on macOS")
+}
+
+func (c *MountCommand) Validate(ctx context.Context) (err error) {
+	return fmt.Errorf("litefs-mount is not available on macOS")
+}
+
+func (c *MountCommand) Run(ctx context.Context) (err error) {
+	return fmt.Errorf("litefs-mount is not available on macOS")
+}

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -45,6 +45,9 @@ func NewMountCommand() *MountCommand {
 	}
 }
 
+func (c *MountCommand) Cmd() *exec.Cmd     { return c.cmd }
+func (c *MountCommand) ExecCh() chan error { return c.execCh }
+
 // ParseFlags parses the command line flags & config file.
 func (c *MountCommand) ParseFlags(ctx context.Context, args []string) (err error) {
 	// Split the args list if there is a double dash arg included. Arguments


### PR DESCRIPTION
While Darwin (macOS) is not supported on LiteFS, this PR makes so that the binary will at least compile and return an error when `litefs mount` is run. Additional debugging tools will be added to the `litefs` binary and it'd be useful to be able to run those from macOS.