### PR TITLE
Fix JournalNode.Read()

### DIFF
--- a/fuse/journal_node.go
+++ b/fuse/journal_node.go
@@ -129,10 +129,12 @@ func newJournalHandle(node *JournalNode, file *os.File) *JournalHandle {
 }
 
 func (h *JournalHandle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
-	n, err := h.file.ReadAt(resp.Data, req.Offset)
-	if n != len(resp.Data) {
-		return io.ErrShortBuffer
+	buf := make([]byte, req.Size)
+	n, err := h.file.ReadAt(buf, req.Offset)
+	if err == io.EOF {
+		err = nil
 	}
+	resp.Data = buf[:n]
 	return err
 }
 


### PR DESCRIPTION
This PR fixes `fuse.JournalNode.Read()` so that it doesn't return an `io.ErrShortBuffer`. This implementation matches the other `Read()` implementations in the `fuse` package.