### PR TITLE
Restrict dirty pgno to commit size

### DIFF
--- a/db.go
+++ b/db.go
@@ -922,7 +922,9 @@ func (db *DB) CommitJournal(mode JournalMode) error {
 	// Build sorted list of dirty page numbers.
 	pgnos := make([]uint32, 0, len(db.dirtyPageSet))
 	for pgno := range db.dirtyPageSet {
-		pgnos = append(pgnos, pgno)
+		if pgno <= commit {
+			pgnos = append(pgnos, pgno)
+		}
 	}
 	sort.Slice(pgnos, func(i, j int) bool { return pgnos[i] < pgnos[j] })
 


### PR DESCRIPTION
This pull request checks that dirty page numbers are within the final database size. There are cases where SQLite can write additional pages past the database and then remove them before committing.