### PR TITLE
Allow retention enforcement to be disabled

### DIFF
--- a/store.go
+++ b/store.go
@@ -623,6 +623,11 @@ func (s *Store) monitorRetention(ctx context.Context) error {
 
 // EnforceRetention enforces retention of LTX files on all databases.
 func (s *Store) EnforceRetention(ctx context.Context) (err error) {
+	// Skip enforcement if not set.
+	if s.RetentionDuration <= 0 {
+		return nil
+	}
+
 	minTime := time.Now().Add(-s.RetentionDuration).UTC()
 
 	for _, db := range s.DBs() {


### PR DESCRIPTION
This PR changes `EnforceRetention()` to be skipped if retention duration is zero or less.

This can be set via the `litefs.yml` config:

```yml
retention:
  duration: "0s"
```

This feature is only meant for testing & debugging. Retention should always be enforced in production. If it isn't, then disks can fill with LTX files as they will never be deleted.