### PR TITLE
Fix frame count calculation on journal recovery

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"io"
 	"os"
 )
 
@@ -16,4 +17,19 @@ func Sync(path string) error {
 		return err
 	}
 	return f.Close()
+}
+
+// ReadFullAt is an implementation of io.ReadFull() but for io.ReaderAt.
+func ReadFullAt(r io.ReaderAt, buf []byte, off int64) (n int, err error) {
+	for n < len(buf) && err == nil {
+		var nn int
+		nn, err = r.ReadAt(buf[n:], off+int64(n))
+		n += nn
+	}
+	if n >= len(buf) {
+		return n, nil
+	} else if n > 0 && err == io.EOF {
+		return n, io.ErrUnexpectedEOF
+	}
+	return n, err
 }

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -1,0 +1,40 @@
+package internal_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/superfly/litefs/internal"
+)
+
+func TestReadFullAt(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		buf := make([]byte, 2)
+		if n, err := internal.ReadFullAt(strings.NewReader("abcde"), buf, 2); err != nil {
+			t.Fatal(err)
+		} else if got, want := n, 2; got != want {
+			t.Fatalf("n=%v, want %v", got, want)
+		} else if got, want := string(buf), "cd"; got != want {
+			t.Fatalf("buf=%q, want %q", got, want)
+		}
+	})
+
+	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
+		buf := make([]byte, 4)
+		if n, err := internal.ReadFullAt(strings.NewReader("abcde"), buf, 2); err != io.ErrUnexpectedEOF {
+			t.Fatalf("unexpected error: %#v", err)
+		} else if got, want := n, 3; got != want {
+			t.Fatalf("n=%v, want %v", got, want)
+		} else if got, want := string(buf), "cde\x00"; got != want {
+			t.Fatalf("buf=%q, want %q", got, want)
+		}
+	})
+
+	t.Run("EOF", func(t *testing.T) {
+		buf := make([]byte, 2)
+		if _, err := internal.ReadFullAt(strings.NewReader(""), buf, 2); err != io.EOF {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+	})
+}


### PR DESCRIPTION
This PR fixes a bug where journals are not recovered correctly if the journal header has not been sync'd and the frame count field is zero.