### PR TITLE
Move WAL commit to after WAL_WRITE_LOCK release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mattn/go-sqlite3 v1.14.16-0.20220918133448-90900be5db1a
 	github.com/prometheus/client_golang v1.13.0
-	github.com/superfly/ltx v0.2.7
+	github.com/superfly/ltx v0.2.8
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/superfly/ltx v0.2.7 h1:nzfhhA3S9iX+zYLO5QkZnFZX6ryxqHpB0NChbJxEGks=
-github.com/superfly/ltx v0.2.7/go.mod h1:aW5e3H7elNGtaW4Cax78hQV6ITIFiYEOeslDPdVwDi0=
+github.com/superfly/ltx v0.2.8 h1:uUnQYAKz65hCFZ7qqI5Lin8J2BfBq36/x4k/GZlh09Q=
+github.com/superfly/ltx v0.2.8/go.mod h1:aW5e3H7elNGtaW4Cax78hQV6ITIFiYEOeslDPdVwDi0=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=


### PR DESCRIPTION
This pull request fixes a bug where the WAL segment is computed before the transaction fully completes. This can occur because SQLite can rewrite sections of the WAL as needed and then rewrites frame headers at the end. This can cause the database & the LTX files to become out of sync and cause `checksum mismatch` errors.

LiteFS now waits for `WAL_WRITE_LOCK` to be released before computing the transaction's pages. This ensures that the final version of the frames are written before determining the transaction boundaries.