### PR TITLE
Fix Pos() deadlock with file system invalidation

### DIFF
--- a/store.go
+++ b/store.go
@@ -737,7 +737,6 @@ func (v *StoreVar) String() string {
 
 		dbJSON := &dbVarJSON{
 			Name:     db.Name(),
-			PageSize: db.PageSize(),
 			TXID:     ltx.FormatTXID(pos.TXID),
 			Checksum: fmt.Sprintf("%016x", pos.PostApplyChecksum),
 		}


### PR DESCRIPTION
This pull request fixes a deadlock that occurs between `litefs.DB.mu` and the FUSE file system invalidation. Currently, the FUSE library is set to be synchronous so holding the `litefs.DB.mu` lock while committing to the journal and reading the `-pos` file can cause a deadlock.

The fix is to remove the `sync.Mutex` from `litefs.DB` as it was no longer necessary because SQLite obtains locks for all the calls inside that alter data. The `litefs.DB.pos` field has been converted to an `atomic.Value` so that its value can be obtained independently of the SQLite locks. This is useful as a write transaction on the rollback journal would prevent inspection of the position.

Originally reported by @kentcdodds in this Fly.io community forum post: https://community.fly.io/t/site-falls-over-every-few-hours-before-rebooting/8907/37