### PR TITLE
Add `skip-sync` config flag

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -144,6 +144,7 @@ type Config struct {
 	Candidate    bool   `yaml:"candidate"`
 	Debug        bool   `yaml:"debug"`
 	ExitOnError  bool   `yaml:"exit-on-error"`
+	SkipSync     bool   `yaml:"skip-sync"`
 	StrictVerify bool   `yaml:"strict-verify"`
 
 	Retention RetentionConfig `yaml:"retention"`

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -213,12 +213,16 @@ func (c *MountCommand) Run(ctx context.Context) (err error) {
 	log.Printf("http server listening on: %s", c.HTTPServer.URL())
 
 	// Wait until the store either becomes primary or connects to the primary.
-	log.Printf("waiting to connect to cluster")
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-c.Store.ReadyCh():
-		log.Printf("connected to cluster, ready")
+	if c.Config.SkipSync {
+		log.Printf("skipping cluster sync, starting immediately")
+	} else {
+		log.Printf("waiting to connect to cluster")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.Store.ReadyCh():
+			log.Printf("connected to cluster, ready")
+		}
 	}
 
 	// Execute subcommand, if specified in config.


### PR DESCRIPTION
This config field will cause the `litefs mount` to not wait for the node to sync to the cluster before starting the `exec` child process. 