### PR TITLE
Disable fail-fast on CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,6 +31,7 @@ jobs:
     name: "Unit Tests"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         journal_mode: [delete, persist, truncate, wal]
     steps:
@@ -65,6 +66,7 @@ jobs:
     name: "Functional Tests"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         journal_mode: [delete, persist, truncate, wal]
     steps:


### PR DESCRIPTION
This pull request sets `fail-fast` to `false` so CI doesn't stop other jobs in the matrix on one error.