### PR TITLE
Make FUSE layer thinner

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -26,9 +26,9 @@ func TestDB_WriteSnapshotTo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := db.WriteDatabase(dbh, data[0:4096], 0); err != nil {
+	if err := db.WriteDatabaseAt(dbh, data[0:4096], 0); err != nil {
 		t.Fatal(err)
-	} else if err := db.WriteDatabase(dbh, data[4096:8192], 4096); err != nil {
+	} else if err := db.WriteDatabaseAt(dbh, data[4096:8192], 4096); err != nil {
 		t.Fatal(err)
 	}
 
@@ -123,9 +123,9 @@ func TestDB_EnforceRetention(t *testing.T) {
 		// Write first LTX file.
 		if err := writeEmptyJournal(t, db); err != nil {
 			t.Fatal(err)
-		} else if err := db.WriteDatabase(dbh, data[0:4096], 0); err != nil {
+		} else if err := db.WriteDatabaseAt(dbh, data[0:4096], 0); err != nil {
 			t.Fatal(err)
-		} else if err := db.WriteDatabase(dbh, data[4096:8192], 4096); err != nil {
+		} else if err := db.WriteDatabaseAt(dbh, data[4096:8192], 4096); err != nil {
 			t.Fatal(err)
 		} else if err := db.CommitJournal(litefs.JournalModeDelete); err != nil {
 			t.Fatal(err)
@@ -139,7 +139,7 @@ func TestDB_EnforceRetention(t *testing.T) {
 		// Write a second LTX file.
 		if err := writeEmptyJournal(t, db); err != nil {
 			t.Fatal(err)
-		} else if err := db.WriteDatabase(dbh, data[0:4096], 0); err != nil {
+		} else if err := db.WriteDatabaseAt(dbh, data[0:4096], 0); err != nil {
 			t.Fatal(err)
 		} else if err := db.CommitJournal(litefs.JournalModeDelete); err != nil {
 			t.Fatal(err)
@@ -148,7 +148,7 @@ func TestDB_EnforceRetention(t *testing.T) {
 		// Write another LTX file.
 		if err := writeEmptyJournal(t, db); err != nil {
 			t.Fatal(err)
-		} else if err := db.WriteDatabase(dbh, data[0:4096], 0); err != nil {
+		} else if err := db.WriteDatabaseAt(dbh, data[0:4096], 0); err != nil {
 			t.Fatal(err)
 		} else if err := db.CommitJournal(litefs.JournalModeDelete); err != nil {
 			t.Fatal(err)
@@ -180,9 +180,9 @@ func TestDB_EnforceRetention(t *testing.T) {
 		// Write first LTX file.
 		if err := writeEmptyJournal(t, db); err != nil {
 			t.Fatal(err)
-		} else if err := db.WriteDatabase(dbh, data[0:4096], 0); err != nil {
+		} else if err := db.WriteDatabaseAt(dbh, data[0:4096], 0); err != nil {
 			t.Fatal(err)
-		} else if err := db.WriteDatabase(dbh, data[4096:8192], 4096); err != nil {
+		} else if err := db.WriteDatabaseAt(dbh, data[4096:8192], 4096); err != nil {
 			t.Fatal(err)
 		} else if err := db.CommitJournal(litefs.JournalModeDelete); err != nil {
 			t.Fatal(err)
@@ -191,7 +191,7 @@ func TestDB_EnforceRetention(t *testing.T) {
 		// Write a second LTX file.
 		if err := writeEmptyJournal(t, db); err != nil {
 			t.Fatal(err)
-		} else if err := db.WriteDatabase(dbh, data[0:4096], 0); err != nil {
+		} else if err := db.WriteDatabaseAt(dbh, data[0:4096], 0); err != nil {
 			t.Fatal(err)
 		} else if err := db.CommitJournal(litefs.JournalModeDelete); err != nil {
 			t.Fatal(err)

--- a/fuse/root_node.go
+++ b/fuse/root_node.go
@@ -265,17 +265,17 @@ func (n *RootNode) Remove(ctx context.Context, req *fuse.RemoveRequest) (err err
 
 	switch fileType {
 	case litefs.FileTypeJournal:
-		if err := db.CommitJournal(litefs.JournalModeDelete); err != nil {
+		if err := db.RemoveJournal(ctx); err != nil {
 			log.Printf("fuse: commit error: %s", err)
 			return err
 		}
 		return nil
 
 	case litefs.FileTypeWAL:
-		return os.Remove(db.WALPath())
+		return db.RemoveWAL(ctx)
 
 	case litefs.FileTypeSHM:
-		return os.Remove(db.SHMPath())
+		return db.RemoveSHM(ctx)
 
 	default:
 		return fuse.ToErrno(syscall.ENOSYS)


### PR DESCRIPTION
This is a minor PR to move functionality from the FUSE layer into a more well-defined API on the `litefs.DB`. This PR only handles the database file functionality for the most part. Journal, WAL, & SHM will be done in a separate PR. This should help with adding trace logging around higher level state in the future.