### PR TITLE
Add trace logging

### DIFF
--- a/cmd/litefs/main_test.go
+++ b/cmd/litefs/main_test.go
@@ -1,0 +1,31 @@
+package main_test
+
+import (
+	"flag"
+	"log"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/superfly/litefs"
+)
+
+var (
+	debug   = flag.Bool("debug", false, "enable fuse debugging")
+	tracing = flag.Bool("tracing", false, "enable trace logging")
+	funTime = flag.Duration("funtime", 0, "long-running, functional test time")
+)
+
+func init() {
+	log.SetFlags(0)
+	rand.Seed(time.Now().UnixNano())
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if *tracing {
+		litefs.TraceLog = log.New(os.Stdout, "", 0)
+	}
+	os.Exit(m.Run())
+}

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -57,7 +57,8 @@ func (c *MountCommand) ParseFlags(ctx context.Context, args []string) (err error
 	fs := flag.NewFlagSet("litefs-mount", flag.ContinueOnError)
 	configPath := fs.String("config", "", "config file path")
 	noExpandEnv := fs.Bool("no-expand-env", false, "do not expand env vars in config")
-	debug := fs.Bool("debug", false, "enable debug logging")
+	debug := fs.Bool("debug", false, "enable FUSE debug logging")
+	tracing := fs.Bool("tracing", false, "enable trace logging")
 	fs.Usage = func() {
 		fmt.Println(`
 The mount command will mount a LiteFS directory via FUSE and begin communicating
@@ -95,6 +96,11 @@ Arguments:
 	// Override "debug" field if specified on the CLI.
 	if *debug {
 		c.Config.Debug = true
+	}
+
+	// Enable trace logging, if specified.
+	if *tracing {
+		litefs.TraceLog = log.New(os.Stdout, "", 0)
 	}
 
 	return nil

--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql"
 	_ "embed"
-	"flag"
 	"fmt"
 	"log"
 	"math/rand"
@@ -20,16 +19,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 )
-
-var (
-	debug   = flag.Bool("debug", false, "enable fuse debugging")
-	funTime = flag.Duration("funtime", 0, "long-running, functional test time")
-)
-
-func init() {
-	log.SetFlags(0)
-	rand.Seed(time.Now().UnixNano())
-}
 
 func TestSingleNode_OK(t *testing.T) {
 	cmd0 := runMountCommand(t, newMountCommand(t, t.TempDir(), nil))

--- a/fuse/fuse_test.go
+++ b/fuse/fuse_test.go
@@ -13,10 +13,21 @@ import (
 	"github.com/superfly/litefs/fuse"
 )
 
-var debug = flag.Bool("debug", false, "enable fuse debugging")
+var (
+	debug   = flag.Bool("debug", false, "enable fuse debugging")
+	tracing = flag.Bool("tracing", false, "enable trace logging")
+)
 
 func init() {
 	log.SetFlags(0)
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if *tracing {
+		litefs.TraceLog = log.New(os.Stdout, "", 0)
+	}
+	os.Exit(m.Run())
 }
 
 func TestFileTypeFilename(t *testing.T) {


### PR DESCRIPTION
This pull request adds trace logging at the logical database level instead of at the FUSE level. This can be enabled on the `./fuse` & `./cmd/litefs` tests and on `litefs mount` by specifying the `-tracing` flag. This has been added to help with #217.