### PR TITLE
Sync WAL to LTX on startup

### DIFF
--- a/internal/testingutil/testingutil.go
+++ b/internal/testingutil/testingutil.go
@@ -11,8 +11,20 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
+	"github.com/mattn/go-sqlite3"
 )
+
+func init() {
+	// Register a test driver for persisting the WAL after DB.Close()
+	sql.Register("sqlite3-persist-wal", &sqlite3.SQLiteDriver{
+		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+			if err := conn.SetFileControlInt("main", sqlite3.SQLITE_FCNTL_PERSIST_WAL, 1); err != nil {
+				return fmt.Errorf("cannot set file control: %w", err)
+			}
+			return nil
+		},
+	})
+}
 
 var (
 	journalMode = flag.String("journal-mode", "delete", "")


### PR DESCRIPTION
This pull request moves around some of the LTX validation on startup so that we can extract the "WAL" fields from the last LTX header. If this header's WAL salt fields match an existing on-disk WAL file and the LTX's WAL offset + size and less than the on-disk WAL file, then we'll truncate the on-disk WAL file to match the LTX file.

This avoids a condition where a WAL file could sync ahead of the LTX file during a hard shutdown. When this occurs, the checksums would no longer match between the last LTX file and the on-disk database on startup.