### PR TITLE
Rewrite SHM after replica LTX apply

### DIFF
--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -537,10 +537,12 @@ func testFileSystem_Checkpoint(t *testing.T, mode string) {
 		t.Fatal(err)
 	}
 
+	t.Logf("checkpointing...")
 	var row [3]int
 	if err := db.QueryRow(`PRAGMA wal_checkpoint(`+mode+`)`).Scan(&row[0], &row[1], &row[2]); err != nil {
 		t.Fatal(err)
 	}
+	t.Logf("checkpoint DONE")
 
 	t.Logf("PRAGMA wal_checkpoint(%s) => %v", mode, row)
 	if row[0] != 0 {


### PR DESCRIPTION
Previously, the checksum was invalidated on the SHM when an LTX file was applied to a replica. This typically caused the SQLite client to rebuild the file on its own. However, in some cases, that wasn't happening properly.

This PR changes it so that LiteFS itself rebuilds the SHM header. This allows it to properly inject the correct page count and should improve performance slightly.