### PR TITLE
Move debug flag to FUSE config section

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -52,14 +52,14 @@ jobs:
         run: go test -v .
 
       - name: Run FUSE tests
-        run: go test -v -p 1 -timeout 5m ./fuse -debug -journal-mode ${{ matrix.journal_mode }}
+        run: go test -v -p 1 -timeout 5m ./fuse -fuse.debug -journal-mode ${{ matrix.journal_mode }}
         timeout-minutes: 5
 
       - name: Start consul in dev mode
         run: consul agent -dev &
 
       - name: Run cmd tests
-        run: go test -v -p 1 -timeout 5m ./cmd/litefs -debug -journal-mode ${{ matrix.journal_mode }}
+        run: go test -v -p 1 -timeout 5m ./cmd/litefs -fuse.debug -journal-mode ${{ matrix.journal_mode }}
         timeout-minutes: 5
 
   functional:
@@ -84,7 +84,7 @@ jobs:
         run: consul agent -dev &
 
       - name: Run functional tests
-        run: go test -v -p 1 -run=TestFunctional_OK ./cmd/litefs -debug -funtime 30s -journal-mode ${{ matrix.journal_mode }}
+        run: go test -v -p 1 -run=TestFunctional_OK ./cmd/litefs -fuse.debug -funtime 30s -journal-mode ${{ matrix.journal_mode }}
         timeout-minutes: 10
 
   staticcheck:

--- a/cmd/litefs/etc/litefs.yml
+++ b/cmd/litefs/etc/litefs.yml
@@ -18,9 +18,11 @@ exec: "myapp -addr :8080"
 # The candidate flag specifies whether the node can become the primary.
 candidate: true
 
-# The debug flag enables debug logging of all FUSE API calls. This will produce
-# a lot of logging and should not be on for general use.
-debug: false
+# The FUSE section handles settings on the FUSE file system.
+fuse:
+  # The debug flag enables debug logging of all FUSE API calls. This will
+  # produce a lot of logging and should not be on for general use.
+  debug: false
 
 # The retention section specifies how long LTX transaction files should persist
 # before being removed. LTX files are kept on disk so replicas can read them

--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -154,12 +154,12 @@ type Config struct {
 	DataDir      string `yaml:"data-dir"`
 	Exec         string `yaml:"exec"`
 	Candidate    bool   `yaml:"candidate"`
-	Debug        bool   `yaml:"debug"`
 	ExitOnError  bool   `yaml:"exit-on-error"`
 	SkipSync     bool   `yaml:"skip-sync"`
 	StrictVerify bool   `yaml:"strict-verify"`
 
 	Retention RetentionConfig `yaml:"retention"`
+	FUSE      FUSEConfig      `yaml:"fuse"`
 	HTTP      HTTPConfig      `yaml:"http"`
 	Consul    *ConsulConfig   `yaml:"consul"`
 	Static    *StaticConfig   `yaml:"static"`
@@ -180,6 +180,11 @@ func NewConfig() Config {
 type RetentionConfig struct {
 	Duration        time.Duration `yaml:"duration"`
 	MonitorInterval time.Duration `yaml:"monitor-interval"`
+}
+
+// FUSEConfig represents the configuration for the FUSE file system.
+type FUSEConfig struct {
+	Debug bool `yaml:"debug"`
 }
 
 // HTTPConfig represents the configuration for the HTTP server.

--- a/cmd/litefs/main_test.go
+++ b/cmd/litefs/main_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	debug   = flag.Bool("debug", false, "enable fuse debugging")
-	tracing = flag.Bool("tracing", false, "enable trace logging")
-	funTime = flag.Duration("funtime", 0, "long-running, functional test time")
+	fuseDebug = flag.Bool("fuse.debug", false, "enable fuse debugging")
+	tracing   = flag.Bool("tracing", false, "enable trace logging")
+	funTime   = flag.Duration("funtime", 0, "long-running, functional test time")
 )
 
 func init() {

--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -901,7 +901,7 @@ func TestConfigExample(t *testing.T) {
 	if got, want := config.MountDir, "/path/to/mnt"; got != want {
 		t.Fatalf("MountDir=%s, want %s", got, want)
 	}
-	if got, want := config.Debug, false; got != want {
+	if got, want := config.FUSE.Debug, false; got != want {
 		t.Fatalf("Debug=%v, want %v", got, want)
 	}
 	if got, want := config.HTTP.Addr, ":20202"; got != want {
@@ -977,7 +977,7 @@ func newMountCommand(tb testing.TB, dir string, peer *main.MountCommand) *main.M
 	cmd := main.NewMountCommand()
 	cmd.Config.MountDir = filepath.Join(dir, "mnt")
 	cmd.Config.DataDir = filepath.Join(dir, "data")
-	cmd.Config.Debug = *debug
+	cmd.Config.FUSE.Debug = *fuseDebug
 	cmd.Config.StrictVerify = true
 	cmd.Config.HTTP.Addr = ":0"
 	cmd.Config.Consul = &main.ConsulConfig{

--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -706,7 +706,6 @@ func newFileSystem(tb testing.TB, path string, leaser litefs.Leaser) *fuse.FileS
 	tb.Helper()
 
 	store := litefs.NewStore(filepath.Join(path, "data"), true)
-	store.Debug = *debug
 	store.StrictVerify = true
 	store.Leaser = leaser
 	if err := store.Open(); err != nil {
@@ -714,6 +713,7 @@ func newFileSystem(tb testing.TB, path string, leaser litefs.Leaser) *fuse.FileS
 	}
 
 	fs := fuse.NewFileSystem(filepath.Join(path, "mnt"), store)
+	fs.Debug = *fuseDebug
 
 	store.Invalidator = fs
 

--- a/fuse/fuse_test.go
+++ b/fuse/fuse_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	debug   = flag.Bool("debug", false, "enable fuse debugging")
-	tracing = flag.Bool("tracing", false, "enable trace logging")
+	fuseDebug = flag.Bool("fuse.debug", false, "enable fuse debugging")
+	tracing   = flag.Bool("tracing", false, "enable trace logging")
 )
 
 func init() {

--- a/http/server.go
+++ b/http/server.go
@@ -137,9 +137,6 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	case "/metrics":
 		s.promHandler.ServeHTTP(w, r)
 		return
-	case "/sys/debug":
-		s.handleSysDebug(w, r)
-		return
 	}
 
 	switch r.URL.Path {
@@ -379,21 +376,6 @@ func (s *Server) streamLTXSnapshot(ctx context.Context, w http.ResponseWriter, d
 	serverFrameSendCountMetricVec.WithLabelValues(db.Name(), "ltx:snapshot")
 
 	return litefs.Pos{TXID: header.MaxTXID, PostApplyChecksum: trailer.PostApplyChecksum}, nil
-}
-
-func (s *Server) handleSysDebug(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case "GET":
-		_, _ = fmt.Fprintln(w, s.store.Debug)
-	case "PUT":
-		s.store.Debug = true
-		_, _ = fmt.Fprintln(w, "debug logging enabled")
-	case "DELETE":
-		s.store.Debug = false
-		_, _ = fmt.Fprintln(w, "debug logging disabled")
-	default:
-		Error(w, r, fmt.Errorf("method not allowed"), http.StatusMethodNotAllowed)
-	}
 }
 
 func Error(w http.ResponseWriter, r *http.Request, err error, code int) {

--- a/store.go
+++ b/store.go
@@ -62,9 +62,6 @@ type Store struct {
 	// Callback to notify kernel of file changes.
 	Invalidator Invalidator
 
-	// If true, enables debug logging.
-	Debug bool
-
 	// If true, computes and verifies the checksum of the entire database
 	// after every transaction. Should only be used during testing.
 	StrictVerify bool
@@ -709,19 +706,6 @@ func (s *Store) processLTXStreamFrame(ctx context.Context, frame *LTXStreamFrame
 	}
 
 	return nil
-}
-
-// DebugFn is called by FUSE when debug logging is enabled.
-func (s *Store) DebugFn(msg any) {
-	if !s.Debug {
-		return
-	}
-
-	status := "r"
-	if s.IsPrimary() {
-		status = "p"
-	}
-	log.Printf("%s [%s]: %s", s.ID(), status, msg)
 }
 
 var _ expvar.Var = (*StoreVar)(nil)


### PR DESCRIPTION
This pull request moves the `debug` flag into the new `fuse` section of the config. This was typically used for low-level debugging so this doesn't affect most people.

The new config syntax is:

```yml
fuse:
  debug: true
```

The CLI flag on `litefs mount` has also been changed from `-debug` to `-fuse.debug`.