### PR TITLE
Implement rolling trace log

### DIFF
--- a/cmd/litefs/etc/litefs.yml
+++ b/cmd/litefs/etc/litefs.yml
@@ -81,3 +81,19 @@ static:
 
   # Required. The API URL of the primary node.
   advertise-url: "http://localhost:20202"
+
+# The tracing section enables a rolling, on-disk tracing log. This records every
+# operation to the database so it can be verbose and it can degrade performance.
+# This is for debugging only and should not typically be enabled in production.
+tracing:
+  # Output path on disk.
+  path: "/path/to/trace.log"
+
+  # Maximum size of a single trace log before rolling. Specified in megabytes.
+  max-size: 64
+
+  # Maximum number of trace logs to retain.
+  max-count: 10
+
+  # If true, historical logs will be compressed using gzip.
+  compress: true

--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -163,6 +163,7 @@ type Config struct {
 	HTTP      HTTPConfig      `yaml:"http"`
 	Consul    *ConsulConfig   `yaml:"consul"`
 	Static    *StaticConfig   `yaml:"static"`
+	Tracing   TracingConfig   `yaml:"tracing"`
 }
 
 // NewConfig returns a new instance of Config with defaults set.
@@ -173,6 +174,11 @@ func NewConfig() Config {
 	config.Retention.Duration = litefs.DefaultRetentionDuration
 	config.Retention.MonitorInterval = litefs.DefaultRetentionMonitorInterval
 	config.HTTP.Addr = http.DefaultAddr
+
+	config.Tracing.MaxSize = DefaultTracingMaxSize
+	config.Tracing.MaxCount = DefaultTracingMaxCount
+	config.Tracing.Compress = DefaultTracingCompress
+
 	return config
 }
 
@@ -207,6 +213,21 @@ type StaticConfig struct {
 	Primary      bool   `yaml:"primary"`
 	Hostname     string `yaml:"hostname"`
 	AdvertiseURL string `yaml:"advertise-url"`
+}
+
+// Tracing configuration defaults.
+const (
+	DefaultTracingMaxSize  = 64 // MB
+	DefaultTracingMaxCount = 8
+	DefaultTracingCompress = true
+)
+
+// TracingConfig represents the configuration the on-disk trace log.
+type TracingConfig struct {
+	Path     string `yaml:"path"`
+	MaxSize  int    `yaml:"max-size"`
+	MaxCount int    `yaml:"max-count"`
+	Compress bool   `yaml:"compress"`
 }
 
 // ReadConfigFile unmarshals config from filename. If expandEnv is true then

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/superfly/ltx v0.2.10
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
@@ -608,12 +609,15 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
This pull request changes the "trace log" so that it can be written to disk and the logs will automatically be rolled. Trace logging can produce A LOT of data quickly but we typically only care about very recent logs when an issue occurs.

## Usage

The existing `-tracing` flag still works and can be used to enable the trace log via STDOUT. There is also a new `tracing` config section for enabling the trace log printing to disk:

```yml
# The tracing section enables a rolling, on-disk tracing log. This records every
# operation to the database so it can be verbose and it can degrade performance.
# This is for debugging only and should not be enabled in production.
tracing:
  # Output path on disk.
  path: "/path/to/trace.log"

  # Maximum size of a single trace log before rolling. Specified in megabytes.
  max-size: 64

  # Maximum number of trace logs to retain.
  max-count: 10

  # If true, historical logs will be compressed using gzip.
  compress: true
```

This default configuration will produce a file called `/path/to/trace.log` and once that log reaches 64MB then it will be rolled over to a new file with a time-based name (e.g. `/path/to/trace.2022-12-15T14-11-07.991.log.gz`). Once 10 logs files have been produced, the oldest one will be deleted when a new log file is written.