### PR TITLE
Skip lock page on checksum

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -52,7 +52,7 @@ jobs:
         run: go test -v .
 
       - name: Run FUSE tests
-        run: go test -v -p 1 -timeout 5m ./fuse -fuse.debug -journal-mode ${{ matrix.journal_mode }}
+        run: go test -v -p 1 -timeout 5m ./fuse -fuse.debug -long -journal-mode ${{ matrix.journal_mode }}
         timeout-minutes: 5
 
       - name: Start consul in dev mode

--- a/fuse/fuse_test.go
+++ b/fuse/fuse_test.go
@@ -16,6 +16,7 @@ import (
 var (
 	fuseDebug = flag.Bool("fuse.debug", false, "enable fuse debugging")
 	tracing   = flag.Bool("tracing", false, "enable trace logging")
+	long      = flag.Bool("long", false, "run long-running tests")
 )
 
 func init() {

--- a/litefs.go
+++ b/litefs.go
@@ -726,3 +726,8 @@ type walCkptInfo struct {
 	backfillAttempted uint32    // WAL frames perhaps written, or maybe not
 	notUsed0          uint32    // Available for future enhancements
 }
+
+// lockPgno returns the page number where the PENDING_BYTE exists.
+func lockPgno(pageSize uint32) uint32 {
+	return uint32(PENDING_BYTE/int64(pageSize)) + 1
+}


### PR DESCRIPTION
This pull request changes the checksumming to skip the lock page since it is not written to. This page is `262145` on databases with the default 4KB pages.