### PR TITLE
Skip lock page on snapshot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mattn/go-sqlite3 v1.14.16-0.20220918133448-90900be5db1a
 	github.com/prometheus/client_golang v1.13.0
-	github.com/superfly/ltx v0.2.10
+	github.com/superfly/ltx v0.2.11
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -310,6 +310,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/superfly/ltx v0.2.10 h1:gLp+s+PPlvwIkIEoW1YOfq+uzieTFaGVesIlZCSJcSI=
 github.com/superfly/ltx v0.2.10/go.mod h1:aW5e3H7elNGtaW4Cax78hQV6ITIFiYEOeslDPdVwDi0=
+github.com/superfly/ltx v0.2.11 h1:MqKhpa7USoAQDXryJmXdFLmZz8KS3VUhyyri2gJC+vc=
+github.com/superfly/ltx v0.2.11/go.mod h1:aW5e3H7elNGtaW4Cax78hQV6ITIFiYEOeslDPdVwDi0=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=

--- a/litefs.go
+++ b/litefs.go
@@ -726,8 +726,3 @@ type walCkptInfo struct {
 	backfillAttempted uint32    // WAL frames perhaps written, or maybe not
 	notUsed0          uint32    // Available for future enhancements
 }
-
-// lockPgno returns the page number where the PENDING_BYTE exists.
-func lockPgno(pageSize uint32) uint32 {
-	return uint32(PENDING_BYTE/int64(pageSize)) + 1
-}


### PR DESCRIPTION
This pull request also upgrades to LTX v0.2.11 which disallows encoding of lock pages.