### PR TITLE
Checkpoint on primary/replica state change

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -161,6 +161,7 @@ type Config struct {
 	Retention RetentionConfig `yaml:"retention"`
 	FUSE      FUSEConfig      `yaml:"fuse"`
 	HTTP      HTTPConfig      `yaml:"http"`
+	Lease     LeaseConfig     `yaml:"lease"`
 	Consul    *ConsulConfig   `yaml:"consul"`
 	Static    *StaticConfig   `yaml:"static"`
 	Tracing   TracingConfig   `yaml:"tracing"`
@@ -174,6 +175,9 @@ func NewConfig() Config {
 	config.Retention.Duration = litefs.DefaultRetentionDuration
 	config.Retention.MonitorInterval = litefs.DefaultRetentionMonitorInterval
 	config.HTTP.Addr = http.DefaultAddr
+
+	config.Lease.ReconnectDelay = litefs.DefaultReconnectDelay
+	config.Lease.DemoteDelay = litefs.DefaultDemoteDelay
 
 	config.Tracing.MaxSize = DefaultTracingMaxSize
 	config.Tracing.MaxCount = DefaultTracingMaxCount
@@ -196,6 +200,12 @@ type FUSEConfig struct {
 // HTTPConfig represents the configuration for the HTTP server.
 type HTTPConfig struct {
 	Addr string `yaml:"addr"`
+}
+
+// LeaseConfig represents a generic configuration for all lease types.
+type LeaseConfig struct {
+	ReconnectDelay time.Duration `yaml:"reconnect-delay"`
+	DemoteDelay    time.Duration `yaml:"demote-delay"`
 }
 
 // ConsulConfig represents the configuration for a Consul leaser.

--- a/cmd/litefs/main_test.go
+++ b/cmd/litefs/main_test.go
@@ -25,7 +25,7 @@ func init() {
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if *tracing {
-		litefs.TraceLog = log.New(os.Stdout, "", 0)
+		litefs.TraceLog = log.New(os.Stdout, "", litefs.TraceLogFlags)
 	}
 	os.Exit(m.Run())
 }

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -304,6 +304,8 @@ func (c *MountCommand) initStore(ctx context.Context) error {
 	c.Store.StrictVerify = c.Config.StrictVerify
 	c.Store.RetentionDuration = c.Config.Retention.Duration
 	c.Store.RetentionMonitorInterval = c.Config.Retention.MonitorInterval
+	c.Store.ReconnectDelay = c.Config.Lease.ReconnectDelay
+	c.Store.DemoteDelay = c.Config.Lease.DemoteDelay
 	c.Store.Client = http.NewClient()
 	return nil
 }

--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -175,6 +175,14 @@ func (fsys *FileSystem) InvalidatePos(db *litefs.DB) error {
 	return nil
 }
 
+// InvalidateEntry removes the file from the cache.
+func (fsys *FileSystem) InvalidateEntry(name string) error {
+	if err := fsys.server.InvalidateEntry(fsys.root, name); err != nil && err != fuse.ErrNotCached {
+		return err
+	}
+	return nil
+}
+
 // debugFn is called by the underlying FUSE library when debug logging is enabled.
 func (fsys *FileSystem) debugFn(msg any) {
 	status := "r"

--- a/fuse/fuse_test.go
+++ b/fuse/fuse_test.go
@@ -26,7 +26,7 @@ func init() {
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if *tracing {
-		litefs.TraceLog = log.New(os.Stdout, "", 0)
+		litefs.TraceLog = log.New(os.Stdout, "", litefs.TraceLogFlags)
 	}
 	os.Exit(m.Run())
 }

--- a/http/server.go
+++ b/http/server.go
@@ -204,8 +204,8 @@ func (s *Server) handlePostStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("stream connected")
-	defer log.Printf("stream disconnected")
+	log.Printf("%s: stream connected", s.store.ID())
+	defer log.Printf("%s: stream disconnected", s.store.ID())
 
 	serverStreamCountMetric.Inc()
 	defer serverStreamCountMetric.Dec()

--- a/litefs.go
+++ b/litefs.go
@@ -100,8 +100,11 @@ func (t FileType) IsValid() bool {
 	}
 }
 
+// TraceLogFlags are the flags to be used with TraceLog.
+const TraceLogFlags = log.LstdFlags | log.LUTC
+
 // TraceLog is a log for low-level tracing.
-var TraceLog = log.New(io.Discard, "", 0)
+var TraceLog = log.New(io.Discard, "", TraceLogFlags)
 
 // Pos represents the transactional position of a database.
 type Pos struct {
@@ -228,6 +231,7 @@ type Invalidator interface {
 	InvalidateDBRange(db *DB, offset, size int64) error
 	InvalidateSHM(db *DB) error
 	InvalidatePos(db *DB) error
+	InvalidateEntry(name string) error
 }
 
 func assert(condition bool, msg string) {


### PR DESCRIPTION
This pull request fixes a bug when a node loses primary status, moves to a replica, and then performs a recovery. The on-disk WAL may no longer be in sync with the LTX files and can corrupt the database. This primarily affects WAL mode, however, it can in affect the rollback journal in edge cases as well.