### PR TITLE
Remove FUSE debugging on CI testing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -52,14 +52,14 @@ jobs:
         run: go test -v .
 
       - name: Run FUSE tests
-        run: go test -v -p 1 -timeout 5m ./fuse -fuse.debug -long -journal-mode ${{ matrix.journal_mode }}
+        run: go test -v -p 1 -timeout 5m ./fuse -long -journal-mode ${{ matrix.journal_mode }}
         timeout-minutes: 5
 
       - name: Start consul in dev mode
         run: consul agent -dev &
 
       - name: Run cmd tests
-        run: go test -v -p 1 -timeout 5m ./cmd/litefs -fuse.debug -journal-mode ${{ matrix.journal_mode }}
+        run: go test -v -p 1 -timeout 5m ./cmd/litefs -journal-mode ${{ matrix.journal_mode }}
         timeout-minutes: 5
 
   functional:
@@ -84,7 +84,7 @@ jobs:
         run: consul agent -dev &
 
       - name: Run functional tests
-        run: go test -v -p 1 -run=TestFunctional_OK ./cmd/litefs -fuse.debug -funtime 30s -journal-mode ${{ matrix.journal_mode }}
+        run: go test -v -p 1 -run=TestFunctional_OK ./cmd/litefs -funtime 30s -journal-mode ${{ matrix.journal_mode }}
         timeout-minutes: 10
 
   staticcheck:


### PR DESCRIPTION
This PR removes the `-fuse.debug` flag from GitHub Actions CI builds. This flag generates a LOT of logs and Actions doesn't handle that load well. If a test does fail then we can test it locally with the flag enabled for more details.