### PR TITLE
Continue init on database early EOF

### DIFF
--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -150,11 +150,11 @@ func TestSingleNode_DatabaseChecksumMismatch(t *testing.T) {
 
 	switch mode := testingutil.JournalMode(); mode {
 	case "delete", "persist", "truncate":
-		if err := cmd0.Run(context.Background()); err == nil || err.Error() != `cannot open store: open databases: open database("db"): recover ltx: apply ltx: database checksum 9d81a60d39fb4760 does not match LTX post-apply checksum ce5a5d55e91b3cd1` {
+		if err := cmd0.Run(context.Background()); err == nil || err.Error() != `cannot open store: open databases: open database("db"): recover ltx: database checksum 9d81a60d39fb4760 does not match LTX post-apply checksum ce5a5d55e91b3cd1` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	case "wal":
-		if err := cmd0.Run(context.Background()); err == nil || err.Error() != `cannot open store: open databases: open database("db"): recover ltx: apply ltx: database checksum a9e884061ea4e488 does not match LTX post-apply checksum fa337f5ece449f39` {
+		if err := cmd0.Run(context.Background()); err == nil || err.Error() != `cannot open store: open databases: open database("db"): recover ltx: database checksum a9e884061ea4e488 does not match LTX post-apply checksum fa337f5ece449f39` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	default:

--- a/internal/testingutil/testingutil.go
+++ b/internal/testingutil/testingutil.go
@@ -42,7 +42,12 @@ func JournalMode() string {
 }
 
 // PageSize returns the value of -page-size flag
-func PageSize() int { return *pageSize }
+func PageSize() int {
+	if *pageSize == 0 {
+		return 4096
+	}
+	return *pageSize
+}
 
 // OpenSQLDB opens a connection to a SQLite database.
 func OpenSQLDB(tb testing.TB, dsn string) *sql.DB {


### PR DESCRIPTION
This pull request fixes a bug where a partial database file can prevent LiteFS from opening. This can be caused when a replica receives an LTX file that grows the database and the server is shutdown while applying the file. Page numbers are written in order so page 1 (which contains the database header) is written first and contains the database size. However, this doesn't match the actual size of the database since the end of the LTX file had not been written yet.

If an early EOF occurs on startup, LiteFS will now report `"database checksum ending early`" in the log and it will continue to reapply the last LTX file. On success, the database should now be valid and checksums should match.