### PR TITLE
Increase default retention

### DIFF
--- a/store.go
+++ b/store.go
@@ -29,7 +29,7 @@ const (
 	DefaultReconnectDelay = 1 * time.Second
 	DefaultDemoteDelay    = 10 * time.Second
 
-	DefaultRetentionDuration        = 1 * time.Minute
+	DefaultRetentionDuration        = 10 * time.Minute
 	DefaultRetentionMonitorInterval = 1 * time.Minute
 )
 


### PR DESCRIPTION
This pull request changes the default LTX retention from 1 minute to 10 minutes. Many deploys can take over a minute—especially if there is a large database and it needs to be checksummed and validated. In these cases, the retention could elapse and require a new snapshot which is expensive.

Small or medium-sized databases with a high write load may want to reduce this to avoid the storage cost of LTX files but this should be partly mitigated with LTX compression (https://github.com/superfly/litefs/issues/132).

Size-based retention is another approach that should be implemented in the near future as well.