### PR TITLE
Require explicit Consul key

### DIFF
--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -280,10 +280,7 @@ func (c *MountCommand) initConsul(ctx context.Context) (err error) {
 		advertiseURL = fmt.Sprintf("http://%s:%d", hostname, c.HTTPServer.Port())
 	}
 
-	leaser := consul.NewLeaser(c.Config.Consul.URL, hostname, advertiseURL)
-	if v := c.Config.Consul.Key; v != "" {
-		leaser.Key = v
-	}
+	leaser := consul.NewLeaser(c.Config.Consul.URL, c.Config.Consul.Key, hostname, advertiseURL)
 	if v := c.Config.Consul.TTL; v > 0 {
 		leaser.TTL = v
 	}

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -18,7 +18,6 @@ import (
 // Default lease settings.
 const (
 	DefaultSessionName = "litefs"
-	DefaultKey         = "litefs/primary"
 	DefaultTTL         = 10 * time.Second
 	DefaultLockDelay   = 1 * time.Second
 )
@@ -47,13 +46,13 @@ type Leaser struct {
 }
 
 // NewLeaser returns a new instance of Leaser.
-func NewLeaser(consulURL, hostname, advertiseURL string) *Leaser {
+func NewLeaser(consulURL, key, hostname, advertiseURL string) *Leaser {
 	return &Leaser{
 		consulURL:    consulURL,
 		hostname:     hostname,
 		advertiseURL: advertiseURL,
 		SessionName:  DefaultSessionName,
-		Key:          DefaultKey,
+		Key:          key,
 		TTL:          DefaultTTL,
 		LockDelay:    DefaultLockDelay,
 	}
@@ -66,7 +65,9 @@ func (l *Leaser) Open() error {
 		return err
 	}
 
-	if l.hostname == "" {
+	if l.Key == "" {
+		return fmt.Errorf("must specify a consul key")
+	} else if l.hostname == "" {
 		return fmt.Errorf("must specify a hostname for this node")
 	} else if l.advertiseURL == "" {
 		return fmt.Errorf("must specify an advertise URL for this node")


### PR DESCRIPTION
This pull request removes the default Consul key as it is too easy to accidentally connect 2 clusters together if you're using the same Consul. This can have some very unexpected results.

Now, users will need to explicitly state the key they want to use for the cluster:

```yml
consul:
  url: "${FLY_CONSUL_URL}"
  key: "litefs/${FLY_APP_NAME}"
  advertise-url: "http://${HOSTNAME}.vm.${FLY_APP_NAME}.internal:20202"
```

Previously, the key was `"litefs/primary"` but it can be any value that is unique to your cluster (e.g. `"production"`, `"staging"`, etc). On Fly.io, Consul usage is scoped to an organization so it only need to be a unique key within your org.