### PR TITLE
Commit WAL on Handle Close

### DIFF
--- a/fuse/shm_node.go
+++ b/fuse/shm_node.go
@@ -135,7 +135,6 @@ func (h *SHMHandle) Write(ctx context.Context, req *fuse.WriteRequest, resp *fus
 }
 
 func (h *SHMHandle) Flush(ctx context.Context, req *fuse.FlushRequest) error {
-	// TODO(wal): If WAL_WRITE_LOCK(120) has an exclusive lock then call db.CommitWAL()
 	h.node.db.UnlockSHM(ctx, uint64(req.LockOwner))
 	return nil
 }


### PR DESCRIPTION
This pull request fixes an issue where an application shutdown that occurs after the last WAL write but before an explicit call to `Unlock(WRITE)` will cause the write to not be committed to LTX.