### PR TITLE
Move mount directory to FUSE config

### DIFF
--- a/cmd/litefs/etc/litefs.yml
+++ b/cmd/litefs/etc/litefs.yml
@@ -1,8 +1,3 @@
-# Required. The mount directory is the path that will be accessible to
-# applications. The directory must already exist and be accessible to the user
-# running LiteFS.
-mount-dir: "/path/to/mnt"
-
 # The data directory is the path where the underlying transaction data will be
 # stored. It will be created if it does not already exist. If not specified,
 # it will be in a hidden directory next to the mount directory (e.g. a /mnt
@@ -18,8 +13,14 @@ exec: "myapp -addr :8080"
 # The candidate flag specifies whether the node can become the primary.
 candidate: true
 
-# The FUSE section handles settings on the FUSE file system.
+# The FUSE section handles settings on the FUSE file system. FUSE provides a
+# layer for intercepting SQLite transactions on the primary node so they can be
+# shipped to replica nodes transparently.
 fuse:
+  # Required. This is the mount directory that applications will use to access
+  # their SQLite databases.
+  dir: "/litefs"
+
   # The debug flag enables debug logging of all FUSE API calls. This will
   # produce a lot of logging and should not be on for general use.
   debug: false

--- a/cmd/litefs/import_test.go
+++ b/cmd/litefs/import_test.go
@@ -37,7 +37,7 @@ func TestImportCommand_Create(t *testing.T) {
 	}
 
 	// Read from LiteFS mount.
-	db = testingutil.OpenSQLDB(t, filepath.Join(m0.Config.MountDir, "my.db"))
+	db = testingutil.OpenSQLDB(t, filepath.Join(m0.Config.FUSE.Dir, "my.db"))
 	var x int
 	if err := db.QueryRow(`SELECT x FROM t`).Scan(&x); err != nil {
 		t.Fatal(err)
@@ -66,7 +66,7 @@ func TestImportCommand_Overwrite(t *testing.T) {
 	waitForPrimary(t, m0)
 
 	// Generate data into the mount.
-	db := testingutil.OpenSQLDB(t, filepath.Join(m0.Config.MountDir, "db"))
+	db := testingutil.OpenSQLDB(t, filepath.Join(m0.Config.FUSE.Dir, "db"))
 	if _, err := db.Exec(`CREATE TABLE t (x)`); err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestImportCommand_Overwrite(t *testing.T) {
 	}
 
 	// Reconnect and verify correctness.
-	db = testingutil.OpenSQLDB(t, filepath.Join(m0.Config.MountDir, "db"))
+	db = testingutil.OpenSQLDB(t, filepath.Join(m0.Config.FUSE.Dir, "db"))
 	if err := db.QueryRow(`SELECT y FROM u`).Scan(&y); err != nil {
 		t.Fatal(err)
 	} else if got, want := y, 100; got != want {
@@ -117,7 +117,7 @@ func TestImportCommand_Overwrite(t *testing.T) {
 	}
 	m0 = runMountCommand(t, newMountCommand(t, dir, m0))
 
-	db = testingutil.OpenSQLDB(t, filepath.Join(m0.Config.MountDir, "db"))
+	db = testingutil.OpenSQLDB(t, filepath.Join(m0.Config.FUSE.Dir, "db"))
 	var sum int
 	if err := db.QueryRow(`SELECT SUM(y) FROM u`).Scan(&sum); err != nil {
 		t.Fatal(err)

--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -150,7 +150,6 @@ func runMount(ctx context.Context, args []string) error {
 
 // Config represents a configuration for the binary process.
 type Config struct {
-	MountDir     string `yaml:"mount-dir"`
 	DataDir      string `yaml:"data-dir"`
 	Exec         string `yaml:"exec"`
 	Candidate    bool   `yaml:"candidate"`
@@ -194,7 +193,8 @@ type RetentionConfig struct {
 
 // FUSEConfig represents the configuration for the FUSE file system.
 type FUSEConfig struct {
-	Debug bool `yaml:"debug"`
+	Dir   string `yaml:"dir"`
+	Debug bool   `yaml:"debug"`
 }
 
 // HTTPConfig represents the configuration for the HTTP server.

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -153,12 +153,12 @@ func (c *MountCommand) parseConfig(ctx context.Context, configPath string, expan
 
 // Validate validates the application's configuration.
 func (c *MountCommand) Validate(ctx context.Context) (err error) {
-	if c.Config.MountDir == "" {
-		return fmt.Errorf("mount directory required")
+	if c.Config.FUSE.Dir == "" {
+		return fmt.Errorf("fuse directory required")
 	} else if c.Config.DataDir == "" {
 		return fmt.Errorf("data directory required")
-	} else if c.Config.MountDir == c.Config.DataDir {
-		return fmt.Errorf("mount directory and data directory cannot be the same path")
+	} else if c.Config.FUSE.Dir == c.Config.DataDir {
+		return fmt.Errorf("fuse directory and data directory cannot be the same path")
 	}
 
 	// Enforce exactly one lease mode.
@@ -321,7 +321,7 @@ func (c *MountCommand) openStore(ctx context.Context) error {
 
 func (c *MountCommand) initFileSystem(ctx context.Context) error {
 	// Build the file system to interact with the store.
-	fsys := fuse.NewFileSystem(c.Config.MountDir, c.Store)
+	fsys := fuse.NewFileSystem(c.Config.FUSE.Dir, c.Store)
 	fsys.Debug = c.Config.FUSE.Debug
 	if err := fsys.Mount(); err != nil {
 		return fmt.Errorf("cannot open file system: %s", err)


### PR DESCRIPTION
This pull request moves the `mount-dir` config option to a `fuse` subsection and renames it to `dir`.

So the previous config of:

```yml
mount-dir: /path/to/mnt
```

will now be:

```yml
fuse:
  dir: /path/to/mnt
```

I'm also going to change the suggested value in documentation to `/litefs` so it's easy to remember. People tend to get confused by the data and mount directory. I'm going to change the `data-dir` to `/var/lib/litefs` to make it less memorable. :) 

Related to https://github.com/superfly/litefs/issues/164