### PR TITLE
Move data-dir to data section

### DIFF
--- a/cmd/litefs/etc/litefs.yml
+++ b/cmd/litefs/etc/litefs.yml
@@ -1,18 +1,3 @@
-# The data directory is the path where the underlying transaction data will be
-# stored. It will be created if it does not already exist. If not specified,
-# it will be in a hidden directory next to the mount directory (e.g. a /mnt
-# directory will have a /.mnt data directory).
-data-dir: "/path/to/data"
-
-# The exec field specifies a command to run as a subprocess of LiteFS. This
-# command will be executed after LiteFS either becomes primary or is connected
-# to the primary node. LiteFS will forward signals to the subprocess and LiteFS
-# will automatically shut itself down when the subprocess stops.
-exec: "myapp -addr :8080"
-
-# The candidate flag specifies whether the node can become the primary.
-candidate: true
-
 # The FUSE section handles settings on the FUSE file system. FUSE provides a
 # layer for intercepting SQLite transactions on the primary node so they can be
 # shipped to replica nodes transparently.
@@ -25,16 +10,31 @@ fuse:
   # produce a lot of logging and should not be on for general use.
   debug: false
 
-# The retention section specifies how long LTX transaction files should persist
-# before being removed. LTX files are kept on disk so replicas can read them
-# during replication. Because a membership list is not maintained, files are
-# simply pruned after a period time instead of being acknowledged by replicas.
-retention:
+# The data section specifies where internal LiteFS data is stored and how long
+# to retain the transaction files.
+# 
+# Transaction files are used to ship changes to replica nodes so they should
+# persist long enough for replicas to retrieve them, even in the face of a short
+# network interruption or a redeploy. Under high load, these files can grow
+# large so it's not advised to extend retention too long.
+data:
+  # Path to where internal database and transaction files are stored.
+  dir: "/var/lib/litefs"
+
   # The amount of time to keep LTX files. Latest LTX file is always kept.
-  duration: "60s"
+  retention: "10m"
 
   # The frequency with which to check for LTX files to delete.
-  monitor-interval: "60s"
+  retention-monitor-interval: "1m"
+
+# The exec field specifies a command to run as a subprocess of LiteFS. This
+# command will be executed after LiteFS either becomes primary or is connected
+# to the primary node. LiteFS will forward signals to the subprocess and LiteFS
+# will automatically shut itself down when the subprocess stops.
+exec: "myapp -addr :8080"
+
+# The candidate flag specifies whether the node can become the primary.
+candidate: true
 
 # The HTTP section defines settings for the LiteFS HTTP API server. This server
 # is how replicas communicate with the current primary server.

--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -150,20 +150,19 @@ func runMount(ctx context.Context, args []string) error {
 
 // Config represents a configuration for the binary process.
 type Config struct {
-	DataDir      string `yaml:"data-dir"`
 	Exec         string `yaml:"exec"`
 	Candidate    bool   `yaml:"candidate"`
 	ExitOnError  bool   `yaml:"exit-on-error"`
 	SkipSync     bool   `yaml:"skip-sync"`
 	StrictVerify bool   `yaml:"strict-verify"`
 
-	Retention RetentionConfig `yaml:"retention"`
-	FUSE      FUSEConfig      `yaml:"fuse"`
-	HTTP      HTTPConfig      `yaml:"http"`
-	Lease     LeaseConfig     `yaml:"lease"`
-	Consul    *ConsulConfig   `yaml:"consul"`
-	Static    *StaticConfig   `yaml:"static"`
-	Tracing   TracingConfig   `yaml:"tracing"`
+	Data    DataConfig    `yaml:"data"`
+	FUSE    FUSEConfig    `yaml:"fuse"`
+	HTTP    HTTPConfig    `yaml:"http"`
+	Lease   LeaseConfig   `yaml:"lease"`
+	Consul  *ConsulConfig `yaml:"consul"`
+	Static  *StaticConfig `yaml:"static"`
+	Tracing TracingConfig `yaml:"tracing"`
 }
 
 // NewConfig returns a new instance of Config with defaults set.
@@ -171,8 +170,10 @@ func NewConfig() Config {
 	var config Config
 	config.Candidate = true
 	config.ExitOnError = true
-	config.Retention.Duration = litefs.DefaultRetentionDuration
-	config.Retention.MonitorInterval = litefs.DefaultRetentionMonitorInterval
+
+	config.Data.Retention = litefs.DefaultRetention
+	config.Data.RetentionMonitorInterval = litefs.DefaultRetentionMonitorInterval
+
 	config.HTTP.Addr = http.DefaultAddr
 
 	config.Lease.ReconnectDelay = litefs.DefaultReconnectDelay
@@ -185,10 +186,12 @@ func NewConfig() Config {
 	return config
 }
 
-// RetentionConfig represents the configuration for LTX file retention.
-type RetentionConfig struct {
-	Duration        time.Duration `yaml:"duration"`
-	MonitorInterval time.Duration `yaml:"monitor-interval"`
+// DataConfig represents the configuration for internal LiteFS data. This
+// includes database files as well as LTX transaction files.
+type DataConfig struct {
+	Dir                      string        `yaml:"dir"`
+	Retention                time.Duration `yaml:"retention"`
+	RetentionMonitorInterval time.Duration `yaml:"retention-monitor-interval"`
 }
 
 // FUSEConfig represents the configuration for the FUSE file system.

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -155,9 +155,9 @@ func (c *MountCommand) parseConfig(ctx context.Context, configPath string, expan
 func (c *MountCommand) Validate(ctx context.Context) (err error) {
 	if c.Config.FUSE.Dir == "" {
 		return fmt.Errorf("fuse directory required")
-	} else if c.Config.DataDir == "" {
+	} else if c.Config.Data.Dir == "" {
 		return fmt.Errorf("data directory required")
-	} else if c.Config.FUSE.Dir == c.Config.DataDir {
+	} else if c.Config.FUSE.Dir == c.Config.Data.Dir {
 		return fmt.Errorf("fuse directory and data directory cannot be the same path")
 	}
 
@@ -297,10 +297,10 @@ func (c *MountCommand) initConsul(ctx context.Context) (err error) {
 }
 
 func (c *MountCommand) initStore(ctx context.Context) error {
-	c.Store = litefs.NewStore(c.Config.DataDir, c.Config.Candidate)
+	c.Store = litefs.NewStore(c.Config.Data.Dir, c.Config.Candidate)
 	c.Store.StrictVerify = c.Config.StrictVerify
-	c.Store.RetentionDuration = c.Config.Retention.Duration
-	c.Store.RetentionMonitorInterval = c.Config.Retention.MonitorInterval
+	c.Store.Retention = c.Config.Data.Retention
+	c.Store.RetentionMonitorInterval = c.Config.Data.RetentionMonitorInterval
 	c.Store.ReconnectDelay = c.Config.Lease.ReconnectDelay
 	c.Store.DemoteDelay = c.Config.Lease.DemoteDelay
 	c.Store.Client = http.NewClient()

--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -839,8 +839,8 @@ func TestMultiNode_StaticLeaser(t *testing.T) {
 
 func TestMultiNode_EnforceRetention(t *testing.T) {
 	cmd := newMountCommand(t, t.TempDir(), nil)
-	cmd.Config.Retention.Duration = 1 * time.Second
-	cmd.Config.Retention.MonitorInterval = 100 * time.Millisecond
+	cmd.Config.Data.Retention = 1 * time.Second
+	cmd.Config.Data.RetentionMonitorInterval = 100 * time.Millisecond
 	waitForPrimary(t, runMountCommand(t, cmd))
 	db := testingutil.OpenSQLDB(t, filepath.Join(cmd.Config.FUSE.Dir, "db"))
 
@@ -879,8 +879,8 @@ func TestFunctional_OK(t *testing.T) {
 	// Configure nodes with a low retention.
 	newFunCmd := func(peer *main.MountCommand) *main.MountCommand {
 		cmd := newMountCommand(t, t.TempDir(), peer)
-		cmd.Config.Retention.Duration = 2 * time.Second
-		cmd.Config.Retention.MonitorInterval = 1 * time.Second
+		cmd.Config.Data.Retention = 2 * time.Second
+		cmd.Config.Data.RetentionMonitorInterval = 1 * time.Second
 		return cmd
 	}
 
@@ -967,7 +967,7 @@ func TestMountCommand_Validate(t *testing.T) {
 	t.Run("ErrMatchingDirs", func(t *testing.T) {
 		cmd := main.NewMountCommand()
 		cmd.Config.FUSE.Dir = t.TempDir()
-		cmd.Config.DataDir = cmd.Config.FUSE.Dir
+		cmd.Config.Data.Dir = cmd.Config.FUSE.Dir
 		if err := cmd.Validate(context.Background()); err == nil || err.Error() != `fuse directory and data directory cannot be the same path` {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -981,6 +981,9 @@ func TestConfigExample(t *testing.T) {
 	config := main.NewConfig()
 	if err := yaml.Unmarshal(litefsConfig, &config); err != nil {
 		t.Fatal(err)
+	}
+	if got, want := config.Data.Dir, "/var/lib/litefs"; got != want {
+		t.Fatalf("FUSE.Dir=%s, want %s", got, want)
 	}
 	if got, want := config.FUSE.Dir, "/litefs"; got != want {
 		t.Fatalf("FUSE.Dir=%s, want %s", got, want)
@@ -1059,7 +1062,7 @@ func newMountCommand(tb testing.TB, dir string, peer *main.MountCommand) *main.M
 	})
 
 	cmd := main.NewMountCommand()
-	cmd.Config.DataDir = filepath.Join(dir, "data")
+	cmd.Config.Data.Dir = filepath.Join(dir, "data")
 	cmd.Config.FUSE.Dir = filepath.Join(dir, "mnt")
 	cmd.Config.FUSE.Debug = *fuseDebug
 	cmd.Config.StrictVerify = true

--- a/store.go
+++ b/store.go
@@ -29,7 +29,7 @@ const (
 	DefaultReconnectDelay = 1 * time.Second
 	DefaultDemoteDelay    = 10 * time.Second
 
-	DefaultRetentionDuration        = 10 * time.Minute
+	DefaultRetention                = 10 * time.Minute
 	DefaultRetentionMonitorInterval = 1 * time.Minute
 )
 
@@ -66,7 +66,7 @@ type Store struct {
 	DemoteDelay time.Duration
 
 	// Length of time to retain LTX files.
-	RetentionDuration        time.Duration
+	Retention                time.Duration
 	RetentionMonitorInterval time.Duration
 
 	// Callback to notify kernel of file changes.
@@ -96,7 +96,7 @@ func NewStore(path string, candidate bool) *Store {
 		ReconnectDelay: DefaultReconnectDelay,
 		DemoteDelay:    DefaultDemoteDelay,
 
-		RetentionDuration:        DefaultRetentionDuration,
+		Retention:                DefaultRetention,
 		RetentionMonitorInterval: DefaultRetentionMonitorInterval,
 	}
 	s.ctx, s.cancel = context.WithCancel(context.Background())
@@ -680,11 +680,11 @@ func (s *Store) Recover(ctx context.Context) (err error) {
 // EnforceRetention enforces retention of LTX files on all databases.
 func (s *Store) EnforceRetention(ctx context.Context) (err error) {
 	// Skip enforcement if not set.
-	if s.RetentionDuration <= 0 {
+	if s.Retention <= 0 {
 		return nil
 	}
 
-	minTime := time.Now().Add(-s.RetentionDuration).UTC()
+	minTime := time.Now().Add(-s.Retention).UTC()
 
 	for _, db := range s.DBs() {
 		if e := db.EnforceRetention(ctx, minTime); err == nil {


### PR DESCRIPTION
This pull request moves `data-dir` to `data.dir` and consolidates the `retention` fields into the `data` section as well.

If your config looked like this before:

```yml
data-dir: "/var/lib/litefs"

retention:
  duration: "10m"
  monitor-interval: "1m"
```

then it should now look like this:

```yml
data:
  dir: "/var/lib/litefs"
  retention: "10m"
  retention-monitor-interval: "1m"
```