### PR TITLE
Add ref_name to Docker builds

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PLATFORMS: "linux/amd64"
-      VERSION: "${{ github.event_name == 'release' && github.event.release.name || '' }}"
+      VERSION: "${{ github.event_name == 'release' && github.event.release.name || github.ref_name }}"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This pull request adds `ref_name` to the Docker builds if it is not a release build. This makes it easier to track what branch the build is from.