### PR TITLE
Remove static.primary config field

### DIFF
--- a/cmd/litefs/etc/litefs.yml
+++ b/cmd/litefs/etc/litefs.yml
@@ -33,9 +33,6 @@ data:
 # will automatically shut itself down when the subprocess stops.
 exec: "myapp -addr :8080"
 
-# The candidate flag specifies whether the node can become the primary.
-candidate: true
-
 # The HTTP section defines settings for the LiteFS HTTP API server. This server
 # is how replicas communicate with the current primary server.
 http:
@@ -58,6 +55,10 @@ lease:
   # Automatically assigned based on hostname(1) if not set.
   hostname: "localhost"
 
+  # Specifies whether the node can become the primary. If using "static" leasing,
+  # this should be set to true on the primary and false on the replicas.
+  candidate: true
+
   # A Consul server provides leader election and ensures that the responsibility
   # of the primary node can be moved in the event of a deployment or a failure.
   consul:
@@ -79,12 +80,6 @@ lease:
     # This buffer is intended to prevent overlap in leadership due to clock skew
     # or in-flight API calls.
     lock-delay: "5s"
-
-  # Static leadership can be used instead of Consul if only one node should ever
-  # be the primary. Only one node in the cluster can be marked as the "primary".
-  static:
-    # Specifies that the current node is the primary.
-    primary: true
 
 # The tracing section enables a rolling, on-disk tracing log. This records every
 # operation to the database so it can be verbose and it can degrade performance.

--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -214,7 +214,9 @@ type LeaseConfig struct {
 	AdvertiseURL string `yaml:"advertise-url"`
 
 	// Specifies if this node can become primary. Defaults to true.
-	// This can be ignored if using a "static" lease.
+	//
+	// If using a "static" lease, setting this to true makes it the primary.
+	// Replicas in a state lease should set this to false.
 	Candidate bool `yaml:"candidate"`
 
 	// After disconnect, time before node tries to reconnect to primary or
@@ -232,11 +234,6 @@ type LeaseConfig struct {
 		TTL       time.Duration `yaml:"ttl"`
 		LockDelay time.Duration `yaml:"lock-delay"`
 	} `yaml:"consul"`
-
-	// Static lease settings.
-	Static struct {
-		Primary bool `yaml:"primary"`
-	} `yaml:"static"`
 }
 
 // Tracing configuration defaults.

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -236,9 +236,9 @@ func (c *MountCommand) Run(ctx context.Context) (err error) {
 			return fmt.Errorf("cannot init consul: %w", err)
 		}
 	case LeaseTypeStatic:
-		log.Printf("Using static primary: is-primary=%v hostname=%s advertise-url=%s",
-			c.Config.Lease.Static.Primary, c.Config.Lease.Hostname, c.Config.Lease.AdvertiseURL)
-		c.Leaser = litefs.NewStaticLeaser(c.Config.Lease.Static.Primary, c.Config.Lease.Hostname, c.Config.Lease.AdvertiseURL)
+		log.Printf("Using static primary: primary=%v hostname=%s advertise-url=%s",
+			c.Config.Lease.Candidate, c.Config.Lease.Hostname, c.Config.Lease.AdvertiseURL)
+		c.Leaser = litefs.NewStaticLeaser(c.Config.Lease.Candidate, c.Config.Lease.Hostname, c.Config.Lease.AdvertiseURL)
 	default:
 		return fmt.Errorf("invalid lease type: %q", v)
 	}

--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -776,7 +776,7 @@ func TestMultiNode_StaticLeaser(t *testing.T) {
 	cmd0.Config.Lease.Type = "static"
 	cmd0.Config.Lease.Hostname = "cmd0"
 	cmd0.Config.Lease.AdvertiseURL = "http://localhost:20808"
-	cmd0.Config.Lease.Static.Primary = true
+	cmd0.Config.Lease.Candidate = true // primary
 
 	runMountCommand(t, cmd0)
 	waitForPrimary(t, cmd0)
@@ -785,7 +785,7 @@ func TestMultiNode_StaticLeaser(t *testing.T) {
 	cmd1.Config.Lease.Type = "static"
 	cmd1.Config.Lease.Hostname = "cmd0"
 	cmd1.Config.Lease.AdvertiseURL = "http://localhost:20808"
-	cmd1.Config.Lease.Static.Primary = false // replica
+	cmd1.Config.Lease.Candidate = false // replica
 	runMountCommand(t, cmd1)
 
 	db0 := testingutil.OpenSQLDB(t, filepath.Join(cmd0.Config.FUSE.Dir, "db"))
@@ -818,7 +818,7 @@ func TestMultiNode_StaticLeaser(t *testing.T) {
 
 	// Second node is NOT a candidate so it should not become primary.
 	t.Log("waiting to ensure replica is not promoted...")
-	time.Sleep(3 * time.Second)
+	time.Sleep(1 * time.Second)
 	if cmd1.Store.IsPrimary() {
 		t.Fatalf("replica should not have been promoted to primary")
 	}
@@ -830,7 +830,7 @@ func TestMultiNode_StaticLeaser(t *testing.T) {
 	cmd0.Config.Lease.Type = "static"
 	cmd0.Config.Lease.Hostname = "cmd0"
 	cmd0.Config.Lease.AdvertiseURL = "http://localhost:20808"
-	cmd0.Config.Lease.Static.Primary = true
+	cmd0.Config.Lease.Candidate = true
 	runMountCommand(t, cmd0)
 	waitForPrimary(t, cmd0)
 }
@@ -1013,8 +1013,8 @@ func TestConfigExample(t *testing.T) {
 	if got, want := config.Lease.Consul.LockDelay, 5*time.Second; got != want {
 		t.Fatalf("Lease.Consul.LockDelay=%s, want %s", got, want)
 	}
-	if got, want := config.Lease.Static.Primary, true; got != want {
-		t.Fatalf("Lease.Static.Primary=%v, want %v", got, want)
+	if got, want := config.Lease.Candidate, true; got != want {
+		t.Fatalf("Lease.Candidate=%v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
This pull request removes the `lease.static.primary` field in favor of the `lease.candidate` field. The fields were similar enough in functionality that they could be merged.

So if your config was:

```yml
lease:
  type: "static"
  static:
    primary: true
```

then you should change it to:

```yml
lease:
  type: "static"
  candidate: true
```

The `candidate` field should be `true` for the primary and `false` for replicas.