### PR TITLE
Implement LZ4 compression

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -49,7 +49,7 @@ jobs:
         run: fusermount -V
 
       - name: Run unit tests
-        run: go test -v .
+        run: go test -v . ./internal/...
 
       - name: Run FUSE tests
         run: go test -v -p 1 -timeout 5m ./fuse -long -journal-mode ${{ matrix.journal_mode }}

--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -168,6 +168,7 @@ func NewConfig() Config {
 	var config Config
 	config.ExitOnError = true
 
+	config.Data.Compress = true
 	config.Data.Retention = litefs.DefaultRetention
 	config.Data.RetentionMonitorInterval = litefs.DefaultRetentionMonitorInterval
 
@@ -187,7 +188,9 @@ func NewConfig() Config {
 // DataConfig represents the configuration for internal LiteFS data. This
 // includes database files as well as LTX transaction files.
 type DataConfig struct {
-	Dir                      string        `yaml:"dir"`
+	Dir      string `yaml:"dir"`
+	Compress bool   `yaml:"compress"`
+
 	Retention                time.Duration `yaml:"retention"`
 	RetentionMonitorInterval time.Duration `yaml:"retention-monitor-interval"`
 }

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -330,6 +330,7 @@ func (c *MountCommand) initConsul(ctx context.Context) (err error) {
 func (c *MountCommand) initStore(ctx context.Context) error {
 	c.Store = litefs.NewStore(c.Config.Data.Dir, c.Config.Lease.Candidate)
 	c.Store.StrictVerify = c.Config.StrictVerify
+	c.Store.Compress = c.Config.Data.Compress
 	c.Store.Retention = c.Config.Data.Retention
 	c.Store.RetentionMonitorInterval = c.Config.Data.RetentionMonitorInterval
 	c.Store.ReconnectDelay = c.Config.Lease.ReconnectDelay

--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -61,7 +61,7 @@ func TestSingleNode_CorruptLTX(t *testing.T) {
 	// Corrupt one of the LTX files.
 	if f, err := os.OpenFile(cmd0.Store.DB("db").LTXPath(txID, txID), os.O_RDWR, 0666); err != nil {
 		t.Fatal(err)
-	} else if _, err := f.WriteAt([]byte("\xff\xff\xff\xff"), 200); err != nil {
+	} else if _, err := f.WriteAt([]byte("\xff\xff\xff\xff"), 96); err != nil {
 		t.Fatal(err)
 	} else if err := f.Close(); err != nil {
 		t.Fatal(err)
@@ -73,7 +73,7 @@ func TestSingleNode_CorruptLTX(t *testing.T) {
 	} else if err := cmd0.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := cmd0.Run(context.Background()); err == nil || err.Error() != `cannot open store: open databases: open database("db"): sync wal to ltx: validate ltx: file checksum mismatch` {
+	if err := cmd0.Run(context.Background()); err == nil || err.Error() != `cannot open store: open databases: open database("db"): sync wal to ltx: validate ltx: close reader: file checksum mismatch` {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -1137,6 +1137,7 @@ func newMountCommand(tb testing.TB, dir string, peer *main.MountCommand) *main.M
 	cmd.Config.FUSE.Dir = filepath.Join(dir, "mnt")
 	cmd.Config.FUSE.Debug = *fuseDebug
 	cmd.Config.Data.Dir = filepath.Join(dir, "data")
+	cmd.Config.Data.Compress = testingutil.Compress()
 	cmd.Config.StrictVerify = true
 	cmd.Config.HTTP.Addr = ":0"
 	cmd.Config.Lease.ReconnectDelay = 10 * time.Millisecond

--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -805,6 +805,7 @@ func newFileSystem(tb testing.TB, path string, leaser litefs.Leaser) *fuse.FileS
 
 	store := litefs.NewStore(filepath.Join(path, "data"), true)
 	store.StrictVerify = true
+	store.Compress = testingutil.Compress()
 	store.Leaser = leaser
 	if err := store.Open(); err != nil {
 		tb.Fatalf("cannot open store: %s", err)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mattn/go-sqlite3 v1.14.16-0.20220918133448-90900be5db1a
 	github.com/prometheus/client_golang v1.13.0
-	github.com/superfly/ltx v0.2.11
+	github.com/superfly/ltx v0.3.0
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
@@ -38,6 +38,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
@@ -48,4 +49,5 @@ require (
 )
 
 // replace github.com/mattn/go-sqlite3 => ../../mattn/go-sqlite3
+// replace github.com/pierrec/lz4/v4 => ../../pierrec/lz4
 // replace github.com/superfly/ltx => ../ltx

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=
+github.com/pierrec/lz4/v4 v4.1.17/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -312,6 +314,8 @@ github.com/superfly/ltx v0.2.10 h1:gLp+s+PPlvwIkIEoW1YOfq+uzieTFaGVesIlZCSJcSI=
 github.com/superfly/ltx v0.2.10/go.mod h1:aW5e3H7elNGtaW4Cax78hQV6ITIFiYEOeslDPdVwDi0=
 github.com/superfly/ltx v0.2.11 h1:MqKhpa7USoAQDXryJmXdFLmZz8KS3VUhyyri2gJC+vc=
 github.com/superfly/ltx v0.2.11/go.mod h1:aW5e3H7elNGtaW4Cax78hQV6ITIFiYEOeslDPdVwDi0=
+github.com/superfly/ltx v0.3.0 h1:vR9xqNrI9EqcS/Lm6JfdMnmsi/Ek7uGoit1nxnajM8E=
+github.com/superfly/ltx v0.3.0/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -1,0 +1,109 @@
+package chunk
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+)
+
+// EOF is the end-of-file marker value for the size.
+const EOF = uint16(0x0000)
+
+// MaxChunkSize is the largest allowable chunk size (64KB).
+const MaxChunkSize = math.MaxUint16
+
+var _ io.Reader = (*Reader)(nil)
+
+// Reader wraps a stream of chunks and converts it into an io.Reader.
+// This is useful for byte streams where the size is not known beforehand.
+type Reader struct {
+	r   io.Reader          // underlying reader
+	b   [MaxChunkSize]byte // underlying buffer
+	buf []byte             // current buffer
+	eof bool               // true for last chunk
+}
+
+// NewReader implements an io.Reader from a chunked byte stream.
+func NewReader(r io.Reader) *Reader {
+	return &Reader{r: r}
+}
+
+func (r *Reader) Read(p []byte) (n int, err error) {
+	// If we have bytes in the buffer, then copy them to p.
+	if len(r.buf) > 0 {
+		n = copy(p, r.buf)
+		r.buf = r.buf[n:]
+		return n, nil
+	}
+
+	// If no bytes are buffered and we are on the last chunk then return EOF.
+	if r.eof {
+		return 0, io.EOF
+	}
+
+	// Otherwise read next chunk and refill the buffer.
+	var size uint16
+	if err := binary.Read(r.r, binary.BigEndian, &size); err == io.EOF {
+		return 0, io.ErrUnexpectedEOF
+	} else if err != nil {
+		return 0, err
+	}
+
+	// Exit if this is the closing EOF chunk.
+	r.eof = size == EOF
+	if r.eof {
+		return 0, io.EOF
+	}
+
+	// The remaining bits are used for the chunk size (up to 64KB).
+	r.buf = r.b[:size]
+	if _, err := io.ReadFull(r.r, r.buf); err != nil {
+		return 0, err
+	}
+
+	// Copy out as much to the buffer as possible.
+	n = copy(p, r.buf)
+	r.buf = r.buf[n:]
+	return n, nil
+}
+
+var _ io.WriteCloser = (*Writer)(nil)
+
+// Writer wraps an io.Writer to convert it to a chunked byte stream.
+// This is useful for byte streams where the size is not known beforehand.
+type Writer struct {
+	w      io.Writer
+	closed bool
+}
+
+// NewWriter implements an io.Writer from a chunked byte stream.
+func NewWriter(w io.Writer) *Writer {
+	return &Writer{w: w}
+}
+
+// Close closes the writer and writes out a closing EOF chunk.
+func (w *Writer) Close() error {
+	if w.closed {
+		return nil // no-op double close
+	}
+
+	err := binary.Write(w.w, binary.BigEndian, EOF)
+	w.closed = true
+	return err
+}
+
+// Write writes p to the underlying writer with a chunk header.
+func (w *Writer) Write(p []byte) (n int, err error) {
+	// Ignore empty byte slices as zero size is reserved for EOF.
+	if len(p) == 0 {
+		return 0, nil
+	} else if len(p) > MaxChunkSize {
+		return 0, fmt.Errorf("chunk.Writer.Write(): buffer too large (%d bytes)", len(p))
+	}
+
+	if err := binary.Write(w.w, binary.BigEndian, uint16(len(p))); err != nil {
+		return 0, err
+	}
+	return w.w.Write(p)
+}

--- a/internal/chunk/chunk_test.go
+++ b/internal/chunk/chunk_test.go
@@ -1,0 +1,47 @@
+package chunk_test
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/superfly/litefs/internal/chunk"
+)
+
+func TestCopy(t *testing.T) {
+	rand := rand.New(rand.NewSource(0))
+
+	var input, buf bytes.Buffer
+	w := chunk.NewWriter(&buf)
+	for i := 0; i < 1000; i++ {
+		data := make([]byte, rand.Intn(10000))
+		_, _ = rand.Read(data)
+
+		// Save data to a simple buffer.
+		_, _ = input.Write(data)
+
+		// Write to a chunked buffer.
+		if n, err := w.Write(data); err != nil {
+			t.Fatal()
+		} else if got, want := n, len(data); got != want {
+			t.Fatalf("len=%d, want %d", got, want)
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read bytes from the chunked buffer.
+	output, err := io.ReadAll(chunk.NewReader(&buf))
+	if err != nil {
+		t.Fatal(err)
+	} else if got, want := len(output), input.Len(); got != want {
+		t.Fatalf("len(output)=%d, want %d", got, want)
+	} else if got, want := output, input.Bytes(); !bytes.Equal(got, want) {
+		t.Fatalf("output does not match input")
+	}
+
+	t.Logf("total bytes: %d", len(output))
+}

--- a/internal/testingutil/testingutil.go
+++ b/internal/testingutil/testingutil.go
@@ -29,6 +29,7 @@ func init() {
 var (
 	journalMode = flag.String("journal-mode", "delete", "")
 	pageSize    = flag.Int("page-size", 0, "")
+	noCompress  = flag.Bool("no-compress", false, "disable ltx compression")
 )
 
 // IsWALMode returns the true if -journal-mode is set to "wal".
@@ -47,6 +48,11 @@ func PageSize() int {
 		return 4096
 	}
 	return *pageSize
+}
+
+// Compress returns true if LTX compression is enabled.
+func Compress() bool {
+	return !*noCompress
 }
 
 // OpenSQLDB opens a connection to a SQLite database.

--- a/litefs_test.go
+++ b/litefs_test.go
@@ -49,7 +49,7 @@ func TestPos_IsZero(t *testing.T) {
 
 func TestReadWriteStreamFrame(t *testing.T) {
 	t.Run("LTXStreamFrame", func(t *testing.T) {
-		frame := &litefs.LTXStreamFrame{Name: "test.db"}
+		frame := &litefs.LTXStreamFrame{Size: 100, Name: "test.db"}
 
 		var buf bytes.Buffer
 		if err := litefs.WriteStreamFrame(&buf, frame); err != nil {

--- a/store_test.go
+++ b/store_test.go
@@ -136,7 +136,10 @@ func TestStore_OpenAndWriteSnapshot(t *testing.T) {
 	db := store.DB("sqlite.db")
 	if _, _, err := db.WriteSnapshotTo(context.Background(), &buf); err != nil {
 		t.Fatal(err)
-	} else if _, err := io.Copy(io.Discard, ltx.NewReader(&buf)); err != nil {
+	}
+
+	dec := ltx.NewDecoder(&buf)
+	if err := dec.Verify(); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This pull request upgrades to [LTX v0.3.0](https://github.com/superfly/ltx/releases/tag/v0.3.0).

To support this, LiteFS' stream format had to be changed in a **backwards incompatible** way. The body of the LTX stream frame is now implemented as a chunked byte stream. This was needed as we won't always know the size of the LTX file beforehand since LTX files can be compacted together. See the implementation in `internal/chunk` for more details. 