### PR TITLE
Add allow_other FUSE mount option

### DIFF
--- a/cmd/litefs/etc/litefs.yml
+++ b/cmd/litefs/etc/litefs.yml
@@ -6,6 +6,10 @@ fuse:
   # use to access their SQLite databases.
   dir: "/litefs"
 
+  # Set this flag to true to allow non-root users to access mount.
+  # You must set the "user_allow_other" option in /etc/fuse.conf first.
+  allow-other: false
+
   # The debug flag enables debug logging of all FUSE API calls.
   # This will produce a lot of logging. Not for general use.
   debug: false

--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -197,8 +197,9 @@ type DataConfig struct {
 
 // FUSEConfig represents the configuration for the FUSE file system.
 type FUSEConfig struct {
-	Dir   string `yaml:"dir"`
-	Debug bool   `yaml:"debug"`
+	Dir        string `yaml:"dir"`
+	AllowOther bool   `yaml:"allow-other"`
+	Debug      bool   `yaml:"debug"`
 }
 
 // HTTPConfig represents the configuration for the HTTP server.

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -354,6 +354,7 @@ func (c *MountCommand) openStore(ctx context.Context) error {
 func (c *MountCommand) initFileSystem(ctx context.Context) error {
 	// Build the file system to interact with the store.
 	fsys := fuse.NewFileSystem(c.Config.FUSE.Dir, c.Store)
+	fsys.AllowOther = c.Config.FUSE.AllowOther
 	fsys.Debug = c.Config.FUSE.Debug
 	if err := fsys.Mount(); err != nil {
 		return fmt.Errorf("cannot open file system: %s", err)

--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -24,6 +24,10 @@ type FileSystem struct {
 	server *fs.Server
 	root   *RootNode
 
+	// If true, allows other users to access the FUSE mount.
+	// Must set "user_allow_other" option in /etc/fuse.conf as well.
+	AllowOther bool
+
 	// User & Group ID for all files in the filesystem.
 	Uid int
 	Gid int
@@ -63,10 +67,15 @@ func (fsys *FileSystem) Mount() (err error) {
 		return err
 	}
 
-	fsys.conn, err = fuse.Mount(fsys.path,
+	options := []fuse.MountOption{
 		fuse.FSName("litefs"),
 		fuse.LockingPOSIX(),
-	)
+	}
+	if fsys.AllowOther {
+		options = append(options, fuse.AllowOther())
+	}
+
+	fsys.conn, err = fuse.Mount(fsys.path, options...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request adds a `fuse.allow-other` option to the `litefs.yml` config file to allow non-root users to access the FUSE mount. To enable this, set the flag to `true` and also add a `user_allow_other` option `/etc/fuse.conf`.

Fixes #250 

### `/etc/fuse.conf`

```
# user_allow_other - Using the allow_other mount option works fine as root, in
# order to have it work as user you need user_allow_other in /etc/fuse.conf as
# well. (This option allows users to use the allow_other option.) You need
# allow_other if you want users other than the owner to access a mounted fuse.
# This option must appear on a line by itself. There is no value, just the
# presence of the option.

user_allow_other
```

