### PR TITLE
Expose replication latency via FUSE

### DIFF
--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -184,6 +184,19 @@ func (fsys *FileSystem) InvalidatePos(db *litefs.DB) error {
 	return nil
 }
 
+// InvalidateLatency invalidates the latency file in the kernel page cache.
+func (fsys *FileSystem) InvalidateLatency(db *litefs.DB) error {
+	node := fsys.root.Node(db.Name() + "-latency")
+	if node == nil {
+		return nil
+	}
+
+	if err := fsys.server.InvalidateNodeData(node); err != nil && err != fuse.ErrNotCached {
+		return err
+	}
+	return nil
+}
+
 // InvalidateEntry removes the file from the cache.
 func (fsys *FileSystem) InvalidateEntry(name string) error {
 	if err := fsys.server.InvalidateEntry(fsys.root, name); err != nil && err != fuse.ErrNotCached {

--- a/fuse/fuse.go
+++ b/fuse/fuse.go
@@ -23,6 +23,8 @@ func FileTypeFilename(t litefs.FileType) string {
 		return "shm"
 	case litefs.FileTypePos:
 		return "pos"
+	case litefs.FileTypeLatency:
+		return "latency"
 	default:
 		panic(fmt.Sprintf("FileTypeFilename(): invalid file type: %d", t))
 	}
@@ -38,6 +40,8 @@ func ParseFilename(name string) (dbName string, fileType litefs.FileType) {
 		return strings.TrimSuffix(name, "-shm"), litefs.FileTypeSHM
 	} else if strings.HasSuffix(name, "-pos") {
 		return strings.TrimSuffix(name, "-pos"), litefs.FileTypePos
+	} else if strings.HasSuffix(name, "-latency") {
+		return strings.TrimSuffix(name, "-latency"), litefs.FileTypeLatency
 	}
 	return name, litefs.FileTypeDatabase
 }

--- a/fuse/latency_node.go
+++ b/fuse/latency_node.go
@@ -1,0 +1,88 @@
+package fuse
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"syscall"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"github.com/superfly/litefs"
+)
+
+var _ fs.Node = (*LatencyNode)(nil)
+var _ fs.NodeOpener = (*LatencyNode)(nil)
+var _ fs.NodeForgetter = (*LatencyNode)(nil)
+var _ fs.NodeListxattrer = (*LatencyNode)(nil)
+var _ fs.NodeGetxattrer = (*LatencyNode)(nil)
+var _ fs.NodeSetxattrer = (*LatencyNode)(nil)
+var _ fs.NodeRemovexattrer = (*LatencyNode)(nil)
+var _ fs.NodePoller = (*LatencyNode)(nil)
+
+// LatencyNode represents a file that returns the current position of the database.
+type LatencyNode struct {
+	fsys *FileSystem
+	db   *litefs.DB
+}
+
+func newLatencyNode(fsys *FileSystem, db *litefs.DB) *LatencyNode {
+	return &LatencyNode{fsys: fsys, db: db}
+}
+
+func (n *LatencyNode) Attr(ctx context.Context, attr *fuse.Attr) error {
+	attr.Mode = 0666
+	attr.Size = uint64(PosFileSize)
+	attr.Uid = uint32(n.fsys.Uid)
+	attr.Gid = uint32(n.fsys.Gid)
+	attr.Valid = 0
+	return nil
+}
+
+func (n *LatencyNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
+	return n, nil
+}
+
+func (n *LatencyNode) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
+	latency := n.db.Latency()
+
+	data := fmt.Sprintf("%d\n", latency)
+	if req.Offset >= int64(len(data)) {
+		return io.EOF
+	}
+
+	// Size buffer to offset/size.
+	data = data[req.Offset:]
+	if len(data) > req.Size {
+		data = data[:req.Size]
+	}
+	resp.Data = []byte(data)
+
+	return nil
+}
+
+func (n *LatencyNode) Forget() { n.fsys.root.ForgetNode(n) }
+
+// ENOSYS is a special return code for xattr requests that will be treated as a permanent failure for any such
+// requests in the future without being sent to the filesystem.
+// Source: https://github.com/libfuse/libfuse/blob/0b6d97cf5938f6b4885e487c3bd7b02144b1ea56/include/fuse_lowlevel.h#L811
+
+func (n *LatencyNode) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *LatencyNode) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *LatencyNode) Setxattr(ctx context.Context, req *fuse.SetxattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *LatencyNode) Removexattr(ctx context.Context, req *fuse.RemovexattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *LatencyNode) Poll(ctx context.Context, req *fuse.PollRequest, resp *fuse.PollResponse) error {
+	return fuse.Errno(syscall.ENOSYS)
+}

--- a/fuse/root_node.go
+++ b/fuse/root_node.go
@@ -139,6 +139,9 @@ func (n *RootNode) lookupDBNode(ctx context.Context, name string) (fs.Node, erro
 	case litefs.FileTypePos:
 		return newPosNode(n.fsys, db), nil
 
+	case litefs.FileTypeLatency:
+		return newLatencyNode(n.fsys, db), nil
+
 	default:
 		return nil, fuse.ToErrno(syscall.ENOSYS)
 	}
@@ -351,6 +354,11 @@ func (h *RootHandle) ReadDirAll(ctx context.Context) (ents []fuse.Dirent, err er
 
 		ents = append(ents, fuse.Dirent{
 			Name: db.Name() + "-pos",
+			Type: fuse.DT_File,
+		})
+
+		ents = append(ents, fuse.Dirent{
+			Name: db.Name() + "-latency",
 			Type: fuse.DT_File,
 		})
 

--- a/litefs.go
+++ b/litefs.go
@@ -88,12 +88,13 @@ const (
 	FileTypeWAL
 	FileTypeSHM
 	FileTypePos
+	FileTypeLatency
 )
 
 // IsValid returns true if t is a valid file type.
 func (t FileType) IsValid() bool {
 	switch t {
-	case FileTypeDatabase, FileTypeJournal, FileTypeWAL, FileTypeSHM, FileTypePos:
+	case FileTypeDatabase, FileTypeJournal, FileTypeWAL, FileTypeSHM, FileTypePos, FileTypeLatency:
 		return true
 	default:
 		return false
@@ -244,6 +245,7 @@ type Invalidator interface {
 	InvalidateDBRange(db *DB, offset, size int64) error
 	InvalidateSHM(db *DB) error
 	InvalidatePos(db *DB) error
+	InvalidateLatency(db *DB) error
 	InvalidateEntry(name string) error
 }
 


### PR DESCRIPTION
Took a stab at implementing https://github.com/superfly/litefs/issues/253 as I was learning more about LiteFS.

I'm representing the latency in milliseconds on disk but that is easily changed. Have only run Go tests, haven't yet tested deployed