### PR TITLE
Implement HALT lock & write forwarding

### DIFF
--- a/cmd/litefs-bench/main.go
+++ b/cmd/litefs-bench/main.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattn/go-sqlite3"
+	_ "github.com/mattn/go-sqlite3"
 	litefsgo "github.com/superfly/litefs-go"
 )
 
@@ -27,18 +27,6 @@ var (
 	maxRowsPerIter = flag.Int("max-rows-per-iter", 10, "maximum number of rows per iteration")
 	iterPerSec     = flag.Float64("iter-per-sec", 0, "iterations per second")
 )
-
-func init() {
-	// Register a test driver for persisting the WAL after DB.Close()
-	sql.Register("sqlite3-persist-wal", &sqlite3.SQLiteDriver{
-		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
-			if err := conn.SetFileControlInt("main", sqlite3.SQLITE_FCNTL_PERSIST_WAL, 1); err != nil {
-				return fmt.Errorf("cannot set file control: %w", err)
-			}
-			return nil
-		},
-	})
-}
 
 func main() {
 	flag.Usage = Usage
@@ -70,7 +58,7 @@ func run(ctx context.Context) error {
 
 	// Open database.
 	dsn = flag.Arg(0)
-	db, err := sql.Open("sqlite3-persist-wal", dsn)
+	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return err
 	}

--- a/cmd/litefs-bench/main.go
+++ b/cmd/litefs-bench/main.go
@@ -12,7 +12,10 @@ import (
 	"time"
 
 	"github.com/mattn/go-sqlite3"
+	litefsgo "github.com/superfly/litefs-go"
 )
+
+var dsn string
 
 var (
 	mode           = flag.String("mode", "", "benchmark mode")
@@ -21,7 +24,7 @@ var (
 	cacheSize      = flag.Int("cache-size", -2000, "SQLite cache size")
 	iter           = flag.Int("iter", 0, "number of iterations")
 	maxRowSize     = flag.Int("max-row-size", 256, "maximum row size")
-	maxRowsPerIter = flag.Int("max-rows-per-iter", 1000, "maximum number of rows per iteration")
+	maxRowsPerIter = flag.Int("max-rows-per-iter", 10, "maximum number of rows per iteration")
 	iterPerSec     = flag.Float64("iter-per-sec", 0, "iterations per second")
 )
 
@@ -66,7 +69,7 @@ func run(ctx context.Context) error {
 	fmt.Printf("running litefs-bench: seed=%d\n", seed)
 
 	// Open database.
-	dsn := flag.Arg(0)
+	dsn = flag.Arg(0)
 	db, err := sql.Open("sqlite3-persist-wal", dsn)
 	if err != nil {
 		return err
@@ -151,49 +154,50 @@ func migrate(ctx context.Context, db *sql.DB) error {
 func runInsertIter(ctx context.Context, db *sql.DB, rand *rand.Rand) error {
 	buf := make([]byte, *maxRowSize)
 
-	tx, err := db.Begin()
-	if err != nil {
-		return fmt.Errorf("begin: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	rowN := rand.Intn(*maxRowsPerIter) + 1
-	for i := 0; i < rowN; i++ {
-		_, _ = rand.Read(buf)
-		num := rand.Int63()
-		rowSize := rand.Intn(*maxRowSize)
-		data := fmt.Sprintf("%x", buf)[:rowSize]
-
-		if _, err := tx.Exec(`INSERT INTO t (num, data) VALUES (?, ?)`, num, data); err != nil {
-			return fmt.Errorf("insert(%d): %w", i, err)
+	return litefsgo.WithHalt(dsn, func() error {
+		tx, err := db.Begin()
+		if err != nil {
+			return fmt.Errorf("begin: %w", err)
 		}
-	}
+		defer func() { _ = tx.Rollback() }()
 
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit: %w", err)
-	}
+		rowN := rand.Intn(*maxRowsPerIter) + 1
+		for i := 0; i < rowN; i++ {
+			_, _ = rand.Read(buf)
+			num := rand.Int63()
+			rowSize := rand.Intn(*maxRowSize)
+			data := fmt.Sprintf("%x", buf)[:rowSize]
 
-	// Update stats on success.
-	statsMu.Lock()
-	defer statsMu.Unlock()
-	stats.TxN++
-	stats.RowN += rowN
-
-	// Vacuum periodically.
-	if rand.Intn(100) == 0 {
-		if _, err := db.Exec(`VACUUM`); err != nil {
-			return fmt.Errorf("vacuum: %w", err)
+			if _, err := tx.Exec(`INSERT INTO t (num, data) VALUES (?, ?)`, num, data); err != nil {
+				return fmt.Errorf("insert(%d): %w", i, err)
+			}
 		}
-	}
 
-	// Truncate periodically.
-	if rand.Intn(10) == 0 {
-		if _, err := db.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
-			return fmt.Errorf("truncate: %w", err)
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit: %w", err)
 		}
-	}
 
-	return nil
+		// Update stats on success.
+		statsMu.Lock()
+		defer statsMu.Unlock()
+		stats.TxN++
+		stats.RowN += rowN
+
+		// Vacuum periodically.
+		if rand.Intn(100) == 0 {
+			if _, err := db.Exec(`VACUUM`); err != nil {
+				return fmt.Errorf("vacuum: %w", err)
+			}
+		}
+
+		// Truncate periodically.
+		if rand.Intn(10) == 0 {
+			if _, err := db.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
+				return fmt.Errorf("truncate: %w", err)
+			}
+		}
+		return err
+	})
 }
 
 // runQueryIter runs a single "query" iteration.

--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -76,7 +76,7 @@ func runMount(ctx context.Context, args []string) error {
 	signalCh := make(chan os.Signal, 2)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 
 	// Set HOSTNAME environment variable, if unset by environment.
 	// This can be used for variable expansion in the config file.
@@ -118,7 +118,7 @@ func runMount(ctx context.Context, args []string) error {
 	var exitCode int
 	select {
 	case err := <-c.ExecCh():
-		cancel()
+		cancel(fmt.Errorf("canceled, subprocess exited"))
 
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -144,7 +144,7 @@ func runMount(ctx context.Context, args []string) error {
 			}
 		}
 
-		cancel()
+		cancel(fmt.Errorf("canceled, signal received"))
 		fmt.Println("signal received, litefs shutting down")
 	}
 

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -285,7 +285,7 @@ func (c *MountCommand) Run(ctx context.Context) (err error) {
 		log.Printf("waiting to connect to cluster")
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return context.Cause(ctx)
 		case <-c.Store.ReadyCh():
 			log.Printf("connected to cluster, ready")
 		}
@@ -361,7 +361,7 @@ func (c *MountCommand) openStore(ctx context.Context) error {
 	}
 
 	// Register expvar variable once so it doesn't panic during tests.
-	expvarOnce.Do(func() { expvar.Publish("store", (*litefs.StoreVar)(c.Store)) })
+	expvarOnce.Do(func() { expvar.Publish("store", c.Store.Expvar()) })
 
 	return nil
 }

--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -491,7 +491,7 @@ func TestMultiNode_PrimaryFlipFlop(t *testing.T) {
 	waitForSync(t, "db", cmds...)
 
 	for i := range cmds {
-		t.Logf("CMD[%d]: %s (%v)", i, cmds[i].Store.ID(), cmds[i].Store.IsPrimary())
+		t.Logf("CMD[%d]: %s (%v)", i, litefs.FormatNodeID(cmds[i].Store.ID()), cmds[i].Store.IsPrimary())
 	}
 
 	rand := rand.New(rand.NewSource(0))

--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -15,12 +15,15 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/superfly/litefs"
 	main "github.com/superfly/litefs/cmd/litefs"
 	"github.com/superfly/litefs/internal/testingutil"
-	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/unix"
 )
 
 func TestSingleNode_OK(t *testing.T) {
@@ -152,11 +155,11 @@ func TestSingleNode_DatabaseChecksumMismatch(t *testing.T) {
 
 	switch mode := testingutil.JournalMode(); mode {
 	case "delete", "persist", "truncate":
-		if err := cmd0.Run(context.Background()); err == nil || err.Error() != `cannot open store: open databases: open database("db"): recover ltx: database checksum 9d81a60d39fb4760 does not match LTX post-apply checksum ce5a5d55e91b3cd1` {
+		if err := cmd0.Run(context.Background()); err == nil || err.Error() != `cannot open store: open databases: open database("db"): recover ltx: database checksum 9d81a60d39fb4760 on TXID 0000000000000003 does not match LTX post-apply checksum ce5a5d55e91b3cd1` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	case "wal":
-		if err := cmd0.Run(context.Background()); err == nil || err.Error() != `cannot open store: open databases: open database("db"): recover ltx: database checksum a9e884061ea4e488 does not match LTX post-apply checksum fa337f5ece449f39` {
+		if err := cmd0.Run(context.Background()); err == nil || err.Error() != `cannot open store: open databases: open database("db"): recover ltx: database checksum a9e884061ea4e488 on TXID 0000000000000004 does not match LTX post-apply checksum fa337f5ece449f39` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	default:
@@ -761,6 +764,10 @@ func TestMultiNode_PositionMismatchRecovery(t *testing.T) {
 }
 
 func TestMultiNode_EnsureReadOnlyReplica(t *testing.T) {
+	if testingutil.IsWALMode() {
+		t.Skip("replicas forward writes in wal mode, skipping")
+	}
+
 	cmd0 := runMountCommand(t, newMountCommand(t, t.TempDir(), nil))
 	waitForPrimary(t, cmd0)
 	cmd1 := runMountCommand(t, newMountCommand(t, t.TempDir(), cmd0))
@@ -786,7 +793,287 @@ func TestMultiNode_EnsureReadOnlyReplica(t *testing.T) {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	}
+}
 
+func TestMultiNode_Halt(t *testing.T) {
+	t.Run("Commit", func(t *testing.T) {
+		cmd0 := runMountCommand(t, newMountCommand(t, t.TempDir(), nil))
+		waitForPrimary(t, cmd0)
+		cmd1 := runMountCommand(t, newMountCommand(t, t.TempDir(), cmd0))
+		db0 := testingutil.OpenSQLDB(t, filepath.Join(cmd0.Config.FUSE.Dir, "db"))
+
+		// Create a simple table with a single value.
+		if _, err := db0.Exec(`CREATE TABLE t (x)`); err != nil {
+			t.Fatal(err)
+		} else if _, err := db0.Exec(`INSERT INTO t VALUES (100)`); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := db0.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
+			t.Fatal(err)
+		}
+
+		waitForSync(t, "db", cmd0, cmd1)
+		t.Logf("initializing replica client")
+		db1 := testingutil.OpenSQLDB(t, filepath.Join(cmd1.Config.FUSE.Dir, "db"))
+
+		// Acquire the halt lock.
+		haltLock, err := cmd1.Store.DB("db").AcquireRemoteHaltLock(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Write next transaction to the replica.
+		t.Logf("inserting value from replica")
+		if _, err := db1.Exec(`INSERT INTO t VALUES (200)`); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd1.Store.DB("db").ReleaseRemoteHaltLock(context.Background(), haltLock.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify replica has been updated.
+		t.Logf("reading value from replica")
+		var sum int
+		if err := db1.QueryRow(`SELECT SUM(x) FROM t`).Scan(&sum); err != nil {
+			t.Fatal(err)
+		} else if got, want := sum, 300; got != want {
+			t.Fatalf("sum=%d, want %d", got, want)
+		}
+
+		// Verify primary has been updated.
+		t.Logf("reading value from primary")
+		if err := db0.QueryRow(`SELECT SUM(x) FROM t`).Scan(&sum); err != nil {
+			t.Fatal(err)
+		} else if got, want := sum, 300; got != want {
+			t.Fatalf("sum=%d, want %d", got, want)
+		}
+		t.Logf("done")
+	})
+
+	// Ensure that closing a file handle with a halt lock will unhalt the node.
+	t.Run("ImplicitUnhalt", func(t *testing.T) {
+		cmd0 := runMountCommand(t, newMountCommand(t, t.TempDir(), nil))
+		waitForPrimary(t, cmd0)
+		cmd1 := runMountCommand(t, newMountCommand(t, t.TempDir(), cmd0))
+		db0 := testingutil.OpenSQLDB(t, filepath.Join(cmd0.Config.FUSE.Dir, "db"))
+
+		// Create a simple table with a single value.
+		if _, err := db0.Exec(`CREATE TABLE t (x)`); err != nil {
+			t.Fatal(err)
+		} else if _, err := db0.Exec(`INSERT INTO t VALUES (100)`); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := db0.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
+			t.Fatal(err)
+		}
+
+		waitForSync(t, "db", cmd0, cmd1)
+		t.Logf("initializing replica client")
+		db1 := testingutil.OpenSQLDB(t, filepath.Join(cmd1.Config.FUSE.Dir, "db"))
+
+		// Acquire the halt lock from the replica via FUSE.
+		dbFile, err := os.OpenFile(filepath.Join(cmd1.Config.FUSE.Dir, "db"), os.O_RDWR, 0666)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = dbFile.Close() }()
+
+		if err := syscall.FcntlFlock(dbFile.Fd(), unix.F_OFD_SETLKW, &syscall.Flock_t{
+			Type:  syscall.F_WRLCK,
+			Start: int64(litefs.LockTypeHalt),
+			Len:   1,
+		}); err != nil {
+			t.Fatalf("cannot acquire HALT lock: %s", err)
+		}
+
+		// Write next transaction to the replica.
+		t.Logf("inserting value from replica")
+		if _, err := db1.Exec(`INSERT INTO t VALUES (200)`); err != nil {
+			t.Fatal(err)
+		}
+
+		// Release lock by closing file instead of F_UNLCK.
+		if err := dbFile.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Ensure primary is writeable again.
+		t.Logf("inserting value from primary")
+		if _, err := db0.Exec(`INSERT INTO t VALUES (300)`); err != nil {
+			t.Fatal(err)
+		}
+		waitForSync(t, "db", cmd0, cmd1)
+
+		// Verify replica has been updated.
+		t.Logf("reading value from replica")
+		var sum int
+		if err := db1.QueryRow(`SELECT SUM(x) FROM t`).Scan(&sum); err != nil {
+			t.Fatal(err)
+		} else if got, want := sum, 600; got != want {
+			t.Fatalf("sum=%d, want %d", got, want)
+		}
+
+		// Verify primary has been updated.
+		t.Logf("reading value from primary")
+		if err := db0.QueryRow(`SELECT SUM(x) FROM t`).Scan(&sum); err != nil {
+			t.Fatal(err)
+		} else if got, want := sum, 600; got != want {
+			t.Fatalf("sum=%d, want %d", got, want)
+		}
+		t.Logf("done")
+	})
+
+	t.Run("Rollback", func(t *testing.T) {
+		cmd0 := runMountCommand(t, newMountCommand(t, t.TempDir(), nil))
+		waitForPrimary(t, cmd0)
+		cmd1 := runMountCommand(t, newMountCommand(t, t.TempDir(), cmd0))
+		db0 := testingutil.OpenSQLDB(t, filepath.Join(cmd0.Config.FUSE.Dir, "db"))
+		db1 := testingutil.OpenSQLDB(t, filepath.Join(cmd1.Config.FUSE.Dir, "db"))
+
+		// Create a simple table with a single value.
+		if _, err := db0.Exec(`CREATE TABLE t (x)`); err != nil {
+			t.Fatal(err)
+		} else if _, err := db0.Exec(`INSERT INTO t VALUES (100)`); err != nil {
+			t.Fatal(err)
+		}
+
+		// Ensure we can also write to the replica.
+		waitForSync(t, "db", cmd0, cmd1)
+
+		// Acquire the halt lock.
+		haltLock, err := cmd1.Store.DB("db").AcquireRemoteHaltLock(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Logf("beginning replica transaction")
+		tx, err := db1.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = tx.Rollback() }()
+
+		t.Logf("issuing insert from replica")
+		if _, err := tx.Exec(`INSERT INTO t VALUES (200)`); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("rolling back from replica")
+		if err := tx.Rollback(); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("rollback complete")
+
+		if err := cmd1.Store.DB("db").ReleaseRemoteHaltLock(context.Background(), haltLock.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify replica.
+		var sum int
+		if err := db1.QueryRow(`SELECT SUM(x) FROM t`).Scan(&sum); err != nil {
+			t.Fatal(err)
+		} else if got, want := sum, 100; got != want {
+			t.Fatalf("sum=%d, want %d", got, want)
+		}
+
+		// Verify primary.
+		if err := db0.QueryRow(`SELECT SUM(x) FROM t`).Scan(&sum); err != nil {
+			t.Fatal(err)
+		} else if got, want := sum, 100; got != want {
+			t.Fatalf("sum=%d, want %d", got, want)
+		}
+	})
+
+	t.Run("RollbackWithWrittenWAL", func(t *testing.T) {
+		cmd0 := runMountCommand(t, newMountCommand(t, t.TempDir(), nil))
+		waitForPrimary(t, cmd0)
+		cmd1 := runMountCommand(t, newMountCommand(t, t.TempDir(), cmd0))
+		db0 := testingutil.OpenSQLDB(t, filepath.Join(cmd0.Config.FUSE.Dir, "db"))
+
+		// Create a simple table with a single value.
+		if _, err := db0.Exec(`CREATE TABLE t (x, y)`); err != nil {
+			t.Fatal(err)
+		} else if _, err := db0.Exec(`INSERT INTO t VALUES (100, NULL)`); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := db0.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
+			t.Fatal(err)
+		}
+
+		waitForSync(t, "db", cmd0, cmd1)
+		t.Logf("initializing replica client")
+		db1 := testingutil.OpenSQLDB(t, filepath.Join(cmd1.Config.FUSE.Dir, "db"))
+		if _, err := db1.Exec(`PRAGMA cache_size = 2`); err != nil {
+			t.Fatal(err)
+		}
+
+		// Acquire the halt lock.
+		haltLock, err := cmd1.Store.DB("db").AcquireRemoteHaltLock(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Write next transaction to the replica.
+		t.Logf("inserting value from replica")
+		tx, err := db1.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = tx.Rollback() }()
+
+		// Write enough pages that they flush to the WAL.
+		for i := 0; i < 10; i++ {
+			if _, err := tx.Exec(`INSERT INTO t VALUES (?, ?)`, i, strings.Repeat("x", 2000)); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Rollback transaction.
+		if err := tx.Rollback(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd1.Store.DB("db").ReleaseRemoteHaltLock(context.Background(), haltLock.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write a new transactions over the rolled back one.
+		if _, err := db0.Exec(`INSERT INTO t VALUES (200, NULL)`); err != nil {
+			t.Fatal(err)
+		}
+
+		// Reacquire halt & insert again.
+		haltLock, err = cmd1.Store.DB("db").AcquireRemoteHaltLock(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db1.Exec(`INSERT INTO t VALUES (300, NULL)`); err != nil {
+			t.Fatal(err)
+		}
+		if err := cmd1.Store.DB("db").ReleaseRemoteHaltLock(context.Background(), haltLock.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify replica has been updated.
+		t.Logf("reading value from replica")
+		var sum int
+		if err := db1.QueryRow(`SELECT SUM(x) FROM t`).Scan(&sum); err != nil {
+			t.Fatal(err)
+		} else if got, want := sum, 600; got != want {
+			t.Fatalf("sum=%d, want %d", got, want)
+		}
+
+		// Verify primary has been updated.
+		t.Logf("reading value from primary")
+		if err := db0.QueryRow(`SELECT SUM(x) FROM t`).Scan(&sum); err != nil {
+			t.Fatal(err)
+		} else if got, want := sum, 600; got != want {
+			t.Fatalf("sum=%d, want %d", got, want)
+		}
+	})
 }
 
 func TestMultiNode_Candidate(t *testing.T) {
@@ -1029,7 +1316,7 @@ func TestFunctional_OK(t *testing.T) {
 
 	// Create schema.
 	db := testingutil.OpenSQLDB(t, filepath.Join(cmds[0].Config.FUSE.Dir, "db"))
-	if _, err := db.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT)`); err != nil {
+	if _, err := db.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, node_id INTEGER, value TEXT)`); err != nil {
 		t.Fatal(err)
 	} else if err := db.Close(); err != nil {
 		t.Fatal(err)
@@ -1037,41 +1324,75 @@ func TestFunctional_OK(t *testing.T) {
 	waitForSync(t, "db", cmds...)
 
 	// Continually run queries against nodes.
-	g, ctx := errgroup.WithContext(context.Background())
+	var wg sync.WaitGroup
 	for i, m := range cmds {
 		i, m := i, m
-		g.Go(func() error {
+
+		wg.Add(1)
+		func() {
+			defer wg.Done()
+
 			db := testingutil.OpenSQLDB(t, filepath.Join(m.Config.FUSE.Dir, "db"))
-			ticker := time.NewTicker(10 * time.Millisecond)
+
+			// Open file handle so we can HALT lock.
+			dbFile, err := os.OpenFile(filepath.Join(m.Config.FUSE.Dir, "db"), os.O_RDWR, 0666)
+			if err != nil {
+				t.Errorf("open database file handle: %s", err)
+				return
+			}
+			defer func() { _ = dbFile.Close() }()
+
+			ticker := time.NewTicker(100 * time.Millisecond)
 			defer ticker.Stop()
 
 			for j := 0; ; j++ {
 				select {
 				case <-done:
-					return nil // test time has elapsed
-				case <-ctx.Done():
-					return nil // another goroutine failed
+					return // test time has elapsed
 				case <-ticker.C:
-					if m.Store.IsPrimary() {
-						if _, err := db.Exec(`INSERT INTO t (value) VALUES (?)`, strings.Repeat("x", 200)); err != nil {
-							return fmt.Errorf("cannot insert (node %d, iter %d): %s", i, j, err)
-						}
+					// Acquire HALT lock through FUSE.
+					if err := syscall.FcntlFlock(dbFile.Fd(), unix.F_OFD_SETLKW, &syscall.Flock_t{
+						Type:  syscall.F_WRLCK,
+						Start: int64(litefs.LockTypeHalt),
+						Len:   1,
+					}); err != nil {
+						t.Errorf("cannot acquire HALT lock: %s", err)
+						return
 					}
 
-					var id int
+					t.Logf("%s @ %s: insert", m.Store.LogPrefix(), m.Store.DB("db").Pos())
+					if _, err := db.Exec(`INSERT INTO t (node_id, value) VALUES (?, ?)`, i, strings.Repeat("x", 200)); err != nil {
+						t.Errorf("cannot insert (node %d, iter %d): %s", i, j, err)
+						return
+					}
+
+					// Release HALT lock through FUSE.
+					if err := syscall.FcntlFlock(dbFile.Fd(), unix.F_OFD_SETLKW, &syscall.Flock_t{
+						Type:  syscall.F_UNLCK,
+						Start: int64(litefs.LockTypeHalt),
+						Len:   1,
+					}); err != nil {
+						t.Errorf("cannot release HALT lock: %s", err)
+						return
+					}
+
+					<-ticker.C
+
+					t.Logf("%s @ %s: read", m.Store.LogPrefix(), m.Store.DB("db").Pos())
+
+					var id, nodeID int
 					var value string
-					if err := db.QueryRow(`SELECT id, value FROM t ORDER BY id DESC LIMIT 1`).Scan(&id, &value); err != nil && err != sql.ErrNoRows {
-						return fmt.Errorf("cannot query (node %d, iter %d): %s", i, j, err)
+					if err := db.QueryRow(`SELECT id, node_id, value FROM t ORDER BY id DESC LIMIT 1`).Scan(&id, &nodeID, &value); err != nil && err != sql.ErrNoRows {
+						t.Errorf("cannot query (node %d, iter %d): %s", i, j, err)
+						return
 					}
 				}
 			}
-		})
+		}()
 	}
 
 	// Ensure we have the same data once we resync.
-	if err := g.Wait(); err != nil {
-		t.Fatal(err)
-	}
+	wg.Wait()
 	waitForSync(t, "db", cmds...)
 
 	counts := make([]int, len(cmds))

--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -818,7 +818,7 @@ func TestMultiNode_Halt(t *testing.T) {
 		db1 := testingutil.OpenSQLDB(t, filepath.Join(cmd1.Config.FUSE.Dir, "db"))
 
 		// Acquire the halt lock.
-		haltLock, err := cmd1.Store.DB("db").AcquireRemoteHaltLock(context.Background())
+		haltLock, err := cmd1.Store.DB("db").AcquireRemoteHaltLock(context.Background(), 1000)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -944,7 +944,7 @@ func TestMultiNode_Halt(t *testing.T) {
 		waitForSync(t, "db", cmd0, cmd1)
 
 		// Acquire the halt lock.
-		haltLock, err := cmd1.Store.DB("db").AcquireRemoteHaltLock(context.Background())
+		haltLock, err := cmd1.Store.DB("db").AcquireRemoteHaltLock(context.Background(), 1000)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1011,7 +1011,7 @@ func TestMultiNode_Halt(t *testing.T) {
 		}
 
 		// Acquire the halt lock.
-		haltLock, err := cmd1.Store.DB("db").AcquireRemoteHaltLock(context.Background())
+		haltLock, err := cmd1.Store.DB("db").AcquireRemoteHaltLock(context.Background(), 1000)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1046,7 +1046,7 @@ func TestMultiNode_Halt(t *testing.T) {
 		}
 
 		// Reacquire halt & insert again.
-		haltLock, err = cmd1.Store.DB("db").AcquireRemoteHaltLock(context.Background())
+		haltLock, err = cmd1.Store.DB("db").AcquireRemoteHaltLock(context.Background(), 1000)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/db.go
+++ b/db.go
@@ -1528,6 +1528,7 @@ func (db *DB) CommitWAL(ctx context.Context) (err error) {
 		WALSalt2:         db.wal.salt2,
 		WALOffset:        db.wal.offset,
 		WALSize:          endOffset - db.wal.offset,
+		NodeID:           db.store.ID(),
 	}); err != nil {
 		return fmt.Errorf("cannot encode ltx header: %s", err)
 	}
@@ -1889,6 +1890,7 @@ func (db *DB) CommitJournal(ctx context.Context, mode JournalMode) (err error) {
 		MaxTXID:          txID,
 		Timestamp:        db.Now().UnixMilli(),
 		PreApplyChecksum: prevPos.PostApplyChecksum,
+		NodeID:           db.store.ID(),
 	}); err != nil {
 		return fmt.Errorf("cannot encode ltx header: %s", err)
 	}
@@ -2439,6 +2441,7 @@ func (db *DB) importToLTX(ctx context.Context, r io.Reader) (Pos, error) {
 		MaxTXID:          pos.TXID,
 		Timestamp:        db.Now().UnixMilli(),
 		PreApplyChecksum: preApplyChecksum,
+		NodeID:           db.store.ID(),
 	}); err != nil {
 		return Pos{}, fmt.Errorf("cannot encode ltx header: %s", err)
 	}
@@ -2966,6 +2969,7 @@ func (db *DB) WriteSnapshotTo(ctx context.Context, dst io.Writer) (header ltx.He
 		MinTXID:   1,
 		MaxTXID:   pos.TXID,
 		Timestamp: db.Now().UnixMilli(),
+		NodeID:    db.store.ID(),
 	}); err != nil {
 		return header, trailer, fmt.Errorf("encode ltx header: %w", err)
 	}

--- a/db.go
+++ b/db.go
@@ -1802,7 +1802,7 @@ func (db *DB) UnlockSHM(ctx context.Context, owner uint64) {
 	// Process WAL if we have an exclusive lock on WAL_WRITE_LOCK.
 	if guardSet.Write().State() == RWMutexStateExclusive {
 		if err := db.CommitWAL(ctx); err != nil {
-			log.Printf("commit wal error: %s", err)
+			log.Printf("commit wal error(1): %s", err)
 		}
 	}
 
@@ -2789,7 +2789,7 @@ func (db *DB) Unlock(ctx context.Context, owner uint64, lockTypes []LockType) er
 	// Process WAL if we have an exclusive lock on WAL_WRITE_LOCK.
 	if ContainsLockType(lockTypes, LockTypeWrite) && guardSet.Write().State() == RWMutexStateExclusive {
 		if err := db.CommitWAL(ctx); err != nil {
-			log.Printf("commit wal error: %s", err)
+			log.Printf("commit wal error(2): %s", err)
 		}
 	}
 

--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -199,5 +199,5 @@ func (fsys *FileSystem) debugFn(msg any) {
 	if fsys.store.IsPrimary() {
 		status = "p"
 	}
-	log.Printf("%s [%s]: %s", fsys.store.ID(), status, msg)
+	log.Printf("%s [%s]: %s", litefs.FormatNodeID(fsys.store.ID()), status, msg)
 }

--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -858,7 +858,7 @@ func TestFileSystem_HaltLock(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		dbFile, err := os.OpenFile(dsn, os.O_RDWR, 0666)
+		dbFile, err := os.OpenFile(dsn+"-lock", os.O_RDWR, 0666)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/fuse/fuse.go
+++ b/fuse/fuse.go
@@ -23,6 +23,8 @@ func FileTypeFilename(t litefs.FileType) string {
 		return "shm"
 	case litefs.FileTypePos:
 		return "pos"
+	case litefs.FileTypeLock:
+		return "lock"
 	default:
 		panic(fmt.Sprintf("FileTypeFilename(): invalid file type: %d", t))
 	}
@@ -38,6 +40,8 @@ func ParseFilename(name string) (dbName string, fileType litefs.FileType) {
 		return strings.TrimSuffix(name, "-shm"), litefs.FileTypeSHM
 	} else if strings.HasSuffix(name, "-pos") {
 		return strings.TrimSuffix(name, "-pos"), litefs.FileTypePos
+	} else if strings.HasSuffix(name, "-lock") {
+		return strings.TrimSuffix(name, "-lock"), litefs.FileTypeLock
 	}
 	return name, litefs.FileTypeDatabase
 }

--- a/fuse/lock_node.go
+++ b/fuse/lock_node.go
@@ -1,0 +1,242 @@
+package fuse
+
+import (
+	"context"
+	"errors"
+	"log"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"syscall"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"github.com/superfly/litefs"
+)
+
+var _ fs.Node = (*LockNode)(nil)
+var _ fs.NodeOpener = (*LockNode)(nil)
+var _ fs.NodeForgetter = (*LockNode)(nil)
+var _ fs.NodeListxattrer = (*LockNode)(nil)
+var _ fs.NodeGetxattrer = (*LockNode)(nil)
+var _ fs.NodeSetxattrer = (*LockNode)(nil)
+var _ fs.NodeRemovexattrer = (*LockNode)(nil)
+var _ fs.NodePoller = (*LockNode)(nil)
+
+// LockNode represents a file used for non-standard SQLite locks. A separate
+// file is needed because SQLite does not use OFD locks so cloing a handle will
+// also release all locks.
+type LockNode struct {
+	fsys *FileSystem
+	db   *litefs.DB
+}
+
+func newLockNode(fsys *FileSystem, db *litefs.DB) *LockNode {
+	return &LockNode{
+		fsys: fsys,
+		db:   db,
+	}
+}
+
+func (n *LockNode) Attr(ctx context.Context, attr *fuse.Attr) error {
+	attr.Mode = 0444
+	attr.Size = 0
+	attr.Uid = uint32(n.fsys.Uid)
+	attr.Gid = uint32(n.fsys.Gid)
+	attr.Valid = 0
+	return nil
+}
+
+func (n *LockNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
+	return newLockHandle(n), nil
+}
+
+func (n *LockNode) Forget() { n.fsys.root.ForgetNode(n) }
+
+// ENOSYS is a special return code for xattr requests that will be treated as a permanent failure for any such
+// requests in the future without being sent to the filesystem.
+// Source: https://github.com/libfuse/libfuse/blob/0b6d97cf5938f6b4885e487c3bd7b02144b1ea56/include/fuse_lowlevel.h#L811
+
+func (n *LockNode) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *LockNode) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *LockNode) Setxattr(ctx context.Context, req *fuse.SetxattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *LockNode) Removexattr(ctx context.Context, req *fuse.RemovexattrRequest) error {
+	return fuse.ToErrno(syscall.ENOSYS)
+}
+
+func (n *LockNode) Poll(ctx context.Context, req *fuse.PollRequest, resp *fuse.PollResponse) error {
+	return fuse.Errno(syscall.ENOSYS)
+}
+
+var _ fs.Handle = (*LockHandle)(nil)
+var _ fs.HandleReader = (*LockHandle)(nil)
+var _ fs.HandleWriter = (*LockHandle)(nil)
+var _ fs.HandlePOSIXLocker = (*LockHandle)(nil)
+
+// LockHandle represents a file handle to a SQLite database file.
+type LockHandle struct {
+	node *LockNode
+
+	haltLockID     int64
+	haltLock       *litefs.HaltLock
+	haltLockMu     sync.Mutex
+	haltLockCancel atomic.Value
+}
+
+func newLockHandle(node *LockNode) *LockHandle {
+	h := &LockHandle{
+		node:       node,
+		haltLockID: rand.Int63(),
+	}
+	h.haltLockCancel.Store(context.CancelFunc(func() {}))
+	return h
+}
+
+func (h *LockHandle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
+	resp.Data = resp.Data[:0]
+	return nil
+}
+
+func (h *LockHandle) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.WriteResponse) error {
+	log.Printf("fuse write error: cannot write to lock file")
+	return syscall.EIO
+}
+
+func (h *LockHandle) Flush(ctx context.Context, req *fuse.FlushRequest) error {
+	return h.unlockHalt(ctx)
+}
+
+func (h *LockHandle) Release(ctx context.Context, req *fuse.ReleaseRequest) error {
+	return nil
+}
+
+func (h *LockHandle) Lock(ctx context.Context, req *fuse.LockRequest) error {
+	return syscall.ENOSYS
+}
+
+func (h *LockHandle) LockWait(ctx context.Context, req *fuse.LockWaitRequest) (err error) {
+	if req.Lock.Start != req.Lock.End {
+		log.Printf("fuse lock error: only one lock can be acquired on the lock file at a time (%d..%d)", req.Lock.Start, req.Lock.End)
+		return syscall.EINVAL
+	}
+
+	switch req.Lock.Start {
+	case uint64(litefs.LockTypeHalt):
+		return h.lockWaitHalt(ctx, req)
+	default:
+		log.Printf("fuse lock error: invalid lock file byte: %d", req.Lock.Start)
+		return syscall.EINVAL
+	}
+}
+
+func (h *LockHandle) lockWaitHalt(ctx context.Context, req *fuse.LockWaitRequest) (err error) {
+	// Return an error this handle is already waiting for a halt lock.
+	if !h.haltLockMu.TryLock() {
+		log.Printf("lock wait error: handle is already waiting for halt lock")
+		return syscall.ENOLCK
+	}
+	defer h.haltLockMu.Unlock()
+
+	// Return an error if this handle is already holding a halt lock.
+	if h.haltLock != nil {
+		log.Printf("lock wait error: handle already acquired halt lock")
+		return syscall.ENOLCK
+	}
+
+	// Ensure request is cancelable in case this handle is closed while we're waiting.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	h.haltLockCancel.Store(cancel)
+
+	switch typ := req.Lock.Type; typ {
+	case fuse.LockWrite:
+		// Attempt to acquire the remote lock. Return EAGAIN if we timeout and
+		// return no error if this node is already the primary.
+		h.haltLock, err = h.node.db.AcquireRemoteHaltLock(ctx, h.haltLockID)
+		if errors.Is(err, context.Canceled) {
+			if err := ctx.Err(); err != nil {
+				return syscall.EINTR
+			}
+			return syscall.EAGAIN
+		} else if err != nil && err != litefs.ErrNoHaltPrimary {
+			return err
+		}
+		return nil
+
+	case fuse.LockRead:
+		return syscall.ENOSYS
+
+	case fuse.LockUnlock: // Handled via Unlock() method
+		return nil
+
+	default:
+		panic("fuse.lockWait(): invalid POSIX lock type")
+	}
+}
+
+func (h *LockHandle) Unlock(ctx context.Context, req *fuse.UnlockRequest) error {
+	if req.Lock.Start != req.Lock.End {
+		log.Printf("fuse unlock error: only one lock can be released on the lock file at a time (%d..%d)", req.Lock.Start, req.Lock.End)
+		return syscall.EINVAL
+	}
+
+	switch req.Lock.Start {
+	case uint64(litefs.LockTypeHalt):
+		return h.unlockHalt(ctx)
+	default:
+		log.Printf("fuse unlock error: invalid lock file byte: %d", req.Lock.Start)
+		return syscall.EINVAL
+	}
+}
+
+func (h *LockHandle) unlockHalt(ctx context.Context) error {
+	if cancel := h.haltLockCancel.Load().(context.CancelFunc); cancel != nil {
+		cancel()
+	}
+
+	h.haltLockMu.Lock()
+	defer h.haltLockMu.Unlock()
+
+	if h.haltLock == nil {
+		return nil
+	}
+
+	err := h.node.db.ReleaseRemoteHaltLock(ctx, h.haltLockID)
+	if errors.Is(err, context.Canceled) && ctx.Err() != nil {
+		return syscall.EINTR
+	}
+	h.haltLock = nil
+	return err
+}
+
+func (h *LockHandle) QueryLock(ctx context.Context, req *fuse.QueryLockRequest, resp *fuse.QueryLockResponse) error {
+	if req.Lock.Start != req.Lock.End {
+		log.Printf("fuse query lock error: only one lock can be queried on the lock file at a time (%d..%d)", req.Lock.Start, req.Lock.End)
+		return syscall.EINVAL
+	}
+
+	switch req.Lock.Start {
+	case uint64(litefs.LockTypeHalt):
+		if h.node.db.HasRemoteHaltLock() {
+			resp.Lock = fuse.FileLock{
+				Start: req.Lock.Start,
+				End:   req.Lock.End,
+				Type:  fuse.LockWrite,
+				PID:   -1,
+			}
+		}
+		return nil
+	default:
+		log.Printf("fuse query lock error: invalid lock file byte: %d", req.Lock.Start)
+		return syscall.EINVAL
+	}
+}

--- a/fuse/primary_node.go
+++ b/fuse/primary_node.go
@@ -29,7 +29,7 @@ func newPrimaryNode(fsys *FileSystem) *PrimaryNode {
 }
 
 func (n *PrimaryNode) Attr(ctx context.Context, attr *fuse.Attr) error {
-	info := n.fsys.store.PrimaryInfo()
+	_, info := n.fsys.store.PrimaryInfo()
 	if info == nil {
 		return fuse.Errno(syscall.ENOENT)
 	}
@@ -43,7 +43,7 @@ func (n *PrimaryNode) Attr(ctx context.Context, attr *fuse.Attr) error {
 }
 
 func (n *PrimaryNode) ReadAll(ctx context.Context) ([]byte, error) {
-	info := n.fsys.store.PrimaryInfo()
+	_, info := n.fsys.store.PrimaryInfo()
 	if info == nil {
 		return nil, fuse.Errno(syscall.ENOENT)
 	}

--- a/fuse/root_node.go
+++ b/fuse/root_node.go
@@ -139,6 +139,9 @@ func (n *RootNode) lookupDBNode(ctx context.Context, name string) (fs.Node, erro
 	case litefs.FileTypePos:
 		return newPosNode(n.fsys, db), nil
 
+	case litefs.FileTypeLock:
+		return newLockNode(n.fsys, db), nil
+
 	default:
 		return nil, fuse.ToErrno(syscall.ENOSYS)
 	}

--- a/fuse/root_node.go
+++ b/fuse/root_node.go
@@ -93,7 +93,7 @@ func (n *RootNode) Lookup(ctx context.Context, name string) (node fs.Node, err e
 }
 
 func (n *RootNode) lookupPrimaryNode(ctx context.Context) (fs.Node, error) {
-	info := n.fsys.store.PrimaryInfo()
+	_, info := n.fsys.store.PrimaryInfo()
 	if info == nil {
 		return nil, syscall.ENOENT
 	}
@@ -189,7 +189,7 @@ func (n *RootNode) createDatabase(ctx context.Context, dbName string, req *fuse.
 	}
 
 	node := newDatabaseNode(n.fsys, db)
-	return node, &DatabaseHandle{node: node, file: file}, nil
+	return node, newDatabaseHandle(node, file), nil
 }
 
 func (n *RootNode) createJournal(ctx context.Context, dbName string, req *fuse.CreateRequest, resp *fuse.CreateResponse) (fs.Node, fs.Handle, error) {
@@ -332,7 +332,7 @@ func NewRootHandle(node *RootNode) *RootHandle {
 
 func (h *RootHandle) ReadDirAll(ctx context.Context) (ents []fuse.Dirent, err error) {
 	// Show ".primary" file if this is a replica currently connected to the primary.
-	if info := h.node.fsys.store.PrimaryInfo(); info != nil {
+	if _, info := h.node.fsys.store.PrimaryInfo(); info != nil {
 		ents = append(ents, fuse.Dirent{
 			Name: PrimaryFilename,
 			Type: fuse.DT_File,

--- a/fuse/shm_node.go
+++ b/fuse/shm_node.go
@@ -154,8 +154,7 @@ func (h *SHMHandle) LockWait(ctx context.Context, req *fuse.LockWaitRequest) err
 
 func (h *SHMHandle) Unlock(ctx context.Context, req *fuse.UnlockRequest) (err error) {
 	lockTypes := litefs.ParseSHMLockRange(req.Lock.Start, req.Lock.End)
-	h.node.db.Unlock(ctx, uint64(req.LockOwner), lockTypes)
-	return nil
+	return h.node.db.Unlock(ctx, uint64(req.LockOwner), lockTypes)
 }
 
 func (h *SHMHandle) QueryLock(ctx context.Context, req *fuse.QueryLockRequest, resp *fuse.QueryLockResponse) error {

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,11 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mattn/go-sqlite3 v1.14.16-0.20220918133448-90900be5db1a
 	github.com/prometheus/client_golang v1.13.0
+	github.com/superfly/litefs-go v0.0.0-20230221221052-ade9b9d7ae1c
 	github.com/superfly/ltx v0.3.0
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
+	golang.org/x/sys v0.4.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -43,11 +45,11 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
-	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
 
+// replace github.com/superfly/litefs-go => ../litefs-go
 // replace github.com/mattn/go-sqlite3 => ../../mattn/go-sqlite3
 // replace github.com/pierrec/lz4/v4 => ../../pierrec/lz4
 // replace github.com/superfly/ltx => ../ltx

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mattn/go-sqlite3 v1.14.16-0.20220918133448-90900be5db1a
 	github.com/prometheus/client_golang v1.13.0
-	github.com/superfly/litefs-go v0.0.0-20230221221052-ade9b9d7ae1c
+	github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b
 	github.com/superfly/ltx v0.3.1-0.20230223203347-c181ee448157
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.16-0.20220918133448-90900be5db1a
 	github.com/prometheus/client_golang v1.13.0
 	github.com/superfly/litefs-go v0.0.0-20230221221052-ade9b9d7ae1c
-	github.com/superfly/ltx v0.3.0
+	github.com/superfly/ltx v0.3.1-0.20230223203347-c181ee448157
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/sys v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05 h1:UrYe9YkT4Wpm6D+zByEyCJQzDqTPXqTDUI7bZ41i9VE=
-bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05/go.mod h1:h0h5FBYpXThbvSfTqthw+0I4nmHnhTHkO5BoOHsBWqg=
 bazil.org/fuse v0.0.0-20230120002735-62a210ff1fd5 h1:A0NsYy4lDBZAC6QiYeJ4N+XuHIKBpyhAVRMHRQZKTeQ=
 bazil.org/fuse v0.0.0-20230120002735-62a210ff1fd5/go.mod h1:gG3RZAMXCa/OTes6rr9EwusmR1OH1tDDy+cg9c5YliY=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -39,7 +37,6 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/Julusian/godocdown v0.0.0-20170816220326-6d19f8ff2df8/go.mod h1:INZr5t32rG59/5xeltqoCJoNY7e5x/3xoY9WSWVWg74=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -70,8 +67,6 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dvyukov/go-fuzz v0.0.0-20200318091601-be3528f3a813/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
-github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -294,7 +289,6 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
-github.com/robertkrimen/godocdown v0.0.0-20130622164427-0bfa04905481/go.mod h1:C9WhFzY47SzYBIvzFqSvHIR6ROgDo4TtdTuRaOMjF/s=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -303,7 +297,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/stephens2424/writerset v1.0.2/go.mod h1:aS2JhsMn6eA7e82oNmW4rfsgAOp9COBTTl8mzkwADnc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -312,15 +305,12 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/superfly/ltx v0.2.10 h1:gLp+s+PPlvwIkIEoW1YOfq+uzieTFaGVesIlZCSJcSI=
-github.com/superfly/ltx v0.2.10/go.mod h1:aW5e3H7elNGtaW4Cax78hQV6ITIFiYEOeslDPdVwDi0=
-github.com/superfly/ltx v0.2.11 h1:MqKhpa7USoAQDXryJmXdFLmZz8KS3VUhyyri2gJC+vc=
-github.com/superfly/ltx v0.2.11/go.mod h1:aW5e3H7elNGtaW4Cax78hQV6ITIFiYEOeslDPdVwDi0=
+github.com/superfly/litefs-go v0.0.0-20230221221052-ade9b9d7ae1c h1:ZPQL+mMu2qA3CrcZ/mUCqZPVtUCNnXWvo4vfuow7YDA=
+github.com/superfly/litefs-go v0.0.0-20230221221052-ade9b9d7ae1c/go.mod h1:h+GUx1V2s0C5nY73ZN82760eWEJrpMaiDweF31VmJKk=
 github.com/superfly/ltx v0.3.0 h1:vR9xqNrI9EqcS/Lm6JfdMnmsi/Ek7uGoit1nxnajM8E=
 github.com/superfly/ltx v0.3.0/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
-github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -444,7 +434,6 @@ golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -473,8 +462,6 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 h1:Sx/u41w+OwrInGdEckYmEuU5gHoGSL4QbDz3S9s6j4U=
-golang.org/x/sys v0.0.0-20220818161305-2296e01440c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -524,7 +511,6 @@ golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
-golang.org/x/tools v0.0.0-20200423201157-2723c5de0d66/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,8 @@ github.com/superfly/litefs-go v0.0.0-20230221221052-ade9b9d7ae1c h1:ZPQL+mMu2qA3
 github.com/superfly/litefs-go v0.0.0-20230221221052-ade9b9d7ae1c/go.mod h1:h+GUx1V2s0C5nY73ZN82760eWEJrpMaiDweF31VmJKk=
 github.com/superfly/ltx v0.3.0 h1:vR9xqNrI9EqcS/Lm6JfdMnmsi/Ek7uGoit1nxnajM8E=
 github.com/superfly/ltx v0.3.0/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
+github.com/superfly/ltx v0.3.1-0.20230223203347-c181ee448157 h1:eyKxoXJoTCQpbJdXVSTJQtLiPfviMjrrBkMcifs/OKE=
+github.com/superfly/ltx v0.3.1-0.20230223203347-c181ee448157/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -305,10 +305,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/superfly/litefs-go v0.0.0-20230221221052-ade9b9d7ae1c h1:ZPQL+mMu2qA3CrcZ/mUCqZPVtUCNnXWvo4vfuow7YDA=
-github.com/superfly/litefs-go v0.0.0-20230221221052-ade9b9d7ae1c/go.mod h1:h+GUx1V2s0C5nY73ZN82760eWEJrpMaiDweF31VmJKk=
-github.com/superfly/ltx v0.3.0 h1:vR9xqNrI9EqcS/Lm6JfdMnmsi/Ek7uGoit1nxnajM8E=
-github.com/superfly/ltx v0.3.0/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
+github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b h1:+WuhtZFB8fNdPeaMUtuB/U8aknXBXdDW/mBm/HTYJNg=
+github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b/go.mod h1:h+GUx1V2s0C5nY73ZN82760eWEJrpMaiDweF31VmJKk=
 github.com/superfly/ltx v0.3.1-0.20230223203347-c181ee448157 h1:eyKxoXJoTCQpbJdXVSTJQtLiPfviMjrrBkMcifs/OKE=
 github.com/superfly/ltx v0.3.1-0.20230223203347-c181ee448157/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/http/client.go
+++ b/http/client.go
@@ -79,7 +79,7 @@ func (c *Client) Import(ctx context.Context, primaryURL, name string, r io.Reade
 	return nil
 }
 
-func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string) (_ *litefs.HaltLock, retErr error) {
+func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) (_ *litefs.HaltLock, retErr error) {
 	u, err := url.Parse(primaryURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid primary URL: %w", err)
@@ -96,6 +96,7 @@ func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID 
 		Path:   "/halt",
 		RawQuery: (url.Values{
 			"name": []string{name},
+			"id":   []string{strconv.FormatInt(lockID, 10)},
 		}).Encode(),
 	}
 

--- a/http/client.go
+++ b/http/client.go
@@ -79,7 +79,7 @@ func (c *Client) Import(ctx context.Context, primaryURL, name string, r io.Reade
 	return nil
 }
 
-func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID, name string) (_ *litefs.HaltLock, retErr error) {
+func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string) (_ *litefs.HaltLock, retErr error) {
 	u, err := url.Parse(primaryURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid primary URL: %w", err)
@@ -104,7 +104,7 @@ func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID,
 		return nil, err
 	}
 	req = req.WithContext(ctx)
-	req.Header.Set("Litefs-Id", nodeID)
+	req.Header.Set("Litefs-Id", litefs.FormatNodeID(nodeID))
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
@@ -124,7 +124,7 @@ func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID,
 	return &haltLock, nil
 }
 
-func (c *Client) ReleaseHaltLock(ctx context.Context, primaryURL string, nodeID, name string, lockID int64) error {
+func (c *Client) ReleaseHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) error {
 	u, err := url.Parse(primaryURL)
 	if err != nil {
 		return fmt.Errorf("invalid primary URL: %w", err)
@@ -150,7 +150,7 @@ func (c *Client) ReleaseHaltLock(ctx context.Context, primaryURL string, nodeID,
 		return err
 	}
 	req = req.WithContext(ctx)
-	req.Header.Set("Litefs-Id", nodeID)
+	req.Header.Set("Litefs-Id", litefs.FormatNodeID(nodeID))
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
@@ -165,7 +165,7 @@ func (c *Client) ReleaseHaltLock(ctx context.Context, primaryURL string, nodeID,
 	return nil
 }
 
-func (c *Client) Commit(ctx context.Context, primaryURL string, nodeID, name string, lockID int64, r io.Reader) error {
+func (c *Client) Commit(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64, r io.Reader) error {
 	u, err := url.Parse(primaryURL)
 	if err != nil {
 		return fmt.Errorf("invalid primary URL: %w", err)
@@ -191,7 +191,7 @@ func (c *Client) Commit(ctx context.Context, primaryURL string, nodeID, name str
 		return err
 	}
 	req = req.WithContext(ctx)
-	req.Header.Set("Litefs-Id", nodeID)
+	req.Header.Set("Litefs-Id", litefs.FormatNodeID(nodeID))
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
@@ -207,7 +207,7 @@ func (c *Client) Commit(ctx context.Context, primaryURL string, nodeID, name str
 }
 
 // Stream returns a snapshot and continuous stream of WAL updates.
-func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID string, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
+func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
 	u, err := url.Parse(primaryURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid client URL: %w", err)
@@ -235,7 +235,7 @@ func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID string, p
 	}
 	req = req.WithContext(ctx)
 
-	req.Header.Set("Litefs-Id", nodeID)
+	req.Header.Set("Litefs-Id", litefs.FormatNodeID(nodeID))
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/http/client.go
+++ b/http/client.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/superfly/litefs"
+	"github.com/superfly/litefs/internal/chunk"
 	"golang.org/x/net/http2"
 )
 
@@ -37,8 +41,8 @@ func NewClient() *Client {
 }
 
 // Import creates or replaces a SQLite database on the remote LiteFS server.
-func (c *Client) Import(ctx context.Context, rawurl, name string, r io.Reader) error {
-	u, err := url.Parse(rawurl)
+func (c *Client) Import(ctx context.Context, primaryURL, name string, r io.Reader) error {
+	u, err := url.Parse(primaryURL)
 	if err != nil {
 		return fmt.Errorf("invalid client URL: %w", err)
 	} else if u.Scheme != "http" && u.Scheme != "https" {
@@ -75,9 +79,136 @@ func (c *Client) Import(ctx context.Context, rawurl, name string, r io.Reader) e
 	return nil
 }
 
+func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID, name string) (_ *litefs.HaltLock, retErr error) {
+	u, err := url.Parse(primaryURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid primary URL: %w", err)
+	} else if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("invalid URL scheme")
+	} else if u.Host == "" {
+		return nil, fmt.Errorf("URL host required")
+	}
+
+	// Strip off everything but the scheme & host.
+	*u = url.URL{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+		Path:   "/halt",
+		RawQuery: (url.Values{
+			"name": []string{name},
+		}).Encode(),
+	}
+
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Litefs-Id", nodeID)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// If unsuccessful, close stream and return an error.
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("invalid response: code=%d", resp.StatusCode)
+	}
+
+	var haltLock litefs.HaltLock
+	if err := json.NewDecoder(resp.Body).Decode(&haltLock); err != nil {
+		return nil, err
+	}
+	return &haltLock, nil
+}
+
+func (c *Client) ReleaseHaltLock(ctx context.Context, primaryURL string, nodeID, name string, lockID int64) error {
+	u, err := url.Parse(primaryURL)
+	if err != nil {
+		return fmt.Errorf("invalid primary URL: %w", err)
+	} else if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid URL scheme")
+	} else if u.Host == "" {
+		return fmt.Errorf("URL host required")
+	}
+
+	// Strip off everything but the scheme & host.
+	*u = url.URL{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+		Path:   "/halt",
+		RawQuery: (url.Values{
+			"name": []string{name},
+			"id":   []string{strconv.FormatInt(lockID, 10)},
+		}).Encode(),
+	}
+
+	req, err := http.NewRequest("DELETE", u.String(), nil)
+	if err != nil {
+		return err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Litefs-Id", nodeID)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// If unsuccessful, close stream and return an error.
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("invalid response: code=%d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (c *Client) Commit(ctx context.Context, primaryURL string, nodeID, name string, lockID int64, r io.Reader) error {
+	u, err := url.Parse(primaryURL)
+	if err != nil {
+		return fmt.Errorf("invalid primary URL: %w", err)
+	} else if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid URL scheme")
+	} else if u.Host == "" {
+		return fmt.Errorf("URL host required")
+	}
+
+	// Strip off everything but the scheme & host.
+	*u = url.URL{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+		Path:   "/tx",
+		RawQuery: (url.Values{
+			"name":   []string{name},
+			"lockID": []string{strconv.FormatInt(lockID, 10)},
+		}).Encode(),
+	}
+
+	req, err := http.NewRequest("POST", u.String(), r)
+	if err != nil {
+		return err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Litefs-Id", nodeID)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// If unsuccessful, close stream and return an error.
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("invalid response: code=%d", resp.StatusCode)
+	}
+	return nil
+}
+
 // Stream returns a snapshot and continuous stream of WAL updates.
-func (c *Client) Stream(ctx context.Context, rawurl string, nodeID string, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
-	u, err := url.Parse(rawurl)
+func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID string, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
+	u, err := url.Parse(primaryURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid client URL: %w", err)
 	} else if u.Scheme != "http" && u.Scheme != "https" {
@@ -114,4 +245,61 @@ func (c *Client) Stream(ctx context.Context, rawurl string, nodeID string, posMa
 		return nil, fmt.Errorf("invalid response: code=%d", resp.StatusCode)
 	}
 	return resp.Body, nil
+}
+
+// RemoteTx represents a remote transaction created by Client.Begin().
+type RemoteTx struct {
+	id               uint64
+	preApplyChecksum uint64
+	committed        bool
+
+	w io.WriteCloser // request body
+	r io.ReadCloser  // response body
+}
+
+// ID returns the TXID of the transaction.
+func (tx *RemoteTx) ID() uint64 { return tx.id }
+
+// PreApplyChecksum returns checksum of the database before the transaction is applied.
+func (tx *RemoteTx) PreApplyChecksum() uint64 { return tx.preApplyChecksum }
+
+// Commit send the LTX data from r to the remote primary for commit.
+func (tx *RemoteTx) Commit(r io.Reader) error {
+	if tx.committed {
+		return nil
+	}
+
+	defer func() { _ = tx.Rollback() }()
+
+	cw := chunk.NewWriter(tx.w)
+	if _, err := io.Copy(cw, r); err != nil {
+		return fmt.Errorf("write ltx chunked stream: %w", err)
+	} else if err := cw.Close(); err != nil {
+		return fmt.Errorf("close ltx chunked stream: %w", err)
+	}
+
+	// Read an integer status code from the binary to confirm commit.
+	// This should return a code of zero on success.
+	var ret uint32
+	if err := binary.Read(tx.r, binary.BigEndian, &ret); err != nil {
+		return fmt.Errorf("read remote tx confirmation: %w", err)
+	} else if ret != 0 {
+		return fmt.Errorf("remote tx confirmation failed (%d)", ret)
+	}
+
+	tx.committed = true
+
+	return nil
+}
+
+// Rollback closes the connection without sending a transaction, thus rolling back.
+func (tx *RemoteTx) Rollback() error {
+	if err := tx.w.Close(); err != nil {
+		_ = tx.r.Close()
+		return fmt.Errorf("close writer: %w", err)
+	}
+	if err := tx.r.Close(); err != nil {
+		return fmt.Errorf("close reader: %w", err)
+	}
+	return nil
 }

--- a/http/server.go
+++ b/http/server.go
@@ -270,14 +270,6 @@ func (s *Server) handleDeleteHalt(w http.ResponseWriter, r *http.Request) {
 	}
 
 	db.ReleaseHaltLock(r.Context(), lockID)
-
-	/*
-		// Checkpoint WAL so we can apply changes directly to the DB.
-		if err := db.CheckpointNoLock(r.Context()); err != nil {
-			Error(w, r, fmt.Errorf("checkpoint: %w", err), http.StatusInternalServerError)
-			return
-		}
-	*/
 }
 
 func (s *Server) handlePostTx(w http.ResponseWriter, r *http.Request) {
@@ -296,14 +288,6 @@ func (s *Server) handlePostTx(w http.ResponseWriter, r *http.Request) {
 		Error(w, r, fmt.Errorf("database not found: %q", name), http.StatusNotFound)
 		return
 	}
-
-	/*
-		// Checkpoint WAL so we can apply changes directly to the DB.
-		if err := db.CheckpointNoLock(r.Context()); err != nil {
-			Error(w, r, fmt.Errorf("checkpoint: %w", err), http.StatusInternalServerError)
-			return
-		}
-	*/
 
 	// TODO(fwd): Ensure halt lock is held by caller.
 	// TODO(fwd): Prevent halt lock release during copy & apply.

--- a/http/server.go
+++ b/http/server.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"net/http/pprof"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -29,6 +31,8 @@ const (
 	DefaultAddr = ":20202"
 )
 
+var ErrServerClosed = fmt.Errorf("canceled, http server closed")
+
 // Server represents an HTTP API server for LiteFS.
 type Server struct {
 	ln net.Listener
@@ -42,7 +46,7 @@ type Server struct {
 
 	g      errgroup.Group
 	ctx    context.Context
-	cancel func()
+	cancel context.CancelCauseFunc
 }
 
 func NewServer(store *litefs.Store, addr string) *Server {
@@ -50,7 +54,7 @@ func NewServer(store *litefs.Store, addr string) *Server {
 		addr:  addr,
 		store: store,
 	}
-	s.ctx, s.cancel = context.WithCancel(context.Background())
+	s.ctx, s.cancel = context.WithCancelCause(context.Background())
 
 	s.promHandler = promhttp.Handler()
 	s.http2Server = &http2.Server{}
@@ -90,7 +94,7 @@ func (s *Server) Close() (err error) {
 			err = e
 		}
 	}
-	s.cancel()
+	s.cancel(ErrServerClosed)
 	if e := s.g.Wait(); e != nil && err == nil {
 		err = e
 	}
@@ -141,6 +145,24 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch r.URL.Path {
+	case "/halt":
+		switch r.Method {
+		case http.MethodPost:
+			s.handlePostHalt(w, r)
+		case http.MethodDelete:
+			s.handleDeleteHalt(w, r)
+		default:
+			Error(w, r, fmt.Errorf("method not allowed"), http.StatusMethodNotAllowed)
+		}
+
+	case "/tx":
+		switch r.Method {
+		case http.MethodPost:
+			s.handlePostTx(w, r)
+		default:
+			Error(w, r, fmt.Errorf("method not allowed"), http.StatusMethodNotAllowed)
+		}
+
 	case "/import":
 		switch r.Method {
 		case http.MethodPost:
@@ -182,6 +204,120 @@ func (s *Server) handlePostImport(w http.ResponseWriter, r *http.Request) {
 
 	if err := db.Import(r.Context(), r.Body); err != nil {
 		Error(w, r, err, http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *Server) handlePostHalt(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	name := q.Get("name")
+
+	// Cannot issue remote halt lock from this node.
+	if id := r.Header.Get("Litefs-Id"); id == s.store.ID() {
+		Error(w, r, fmt.Errorf("cannot remotely halt self"), http.StatusBadRequest)
+		return
+	}
+
+	// Ensure database exists before attempting a lock.
+	db, err := s.store.CreateDBIfNotExists(name)
+	if err != nil {
+		Error(w, r, fmt.Errorf("create db: %w", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Acquire write locks on behalf of remote node.
+	haltLock, err := db.AcquireHaltLock(r.Context())
+	if err != nil {
+		Error(w, r, fmt.Errorf("acquire halt lock: %w", err), http.StatusInternalServerError)
+		return
+	}
+
+	/*
+		// Checkpoint WAL so we can apply changes directly to the DB.
+		if err := db.CheckpointNoLock(r.Context()); err != nil {
+			Error(w, r, fmt.Errorf("checkpoint: %w", err), http.StatusInternalServerError)
+			return
+		}
+	*/
+
+	// Return lock ID & position to caller.
+	if err := json.NewEncoder(w).Encode(haltLock); err != nil {
+		Error(w, r, err, http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *Server) handleDeleteHalt(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	name := q.Get("name")
+	lockID, err := strconv.ParseInt(q.Get("id"), 10, 64)
+	if err != nil {
+		Error(w, r, fmt.Errorf("invalid id: %q", q.Get("id")), http.StatusBadRequest)
+		return
+	}
+
+	// Cannot issue remote halt lock from this node.
+	if id := r.Header.Get("Litefs-Id"); id == s.store.ID() {
+		Error(w, r, fmt.Errorf("cannot remotely unhalt self"), http.StatusBadRequest)
+		return
+	}
+
+	// Database should have been created from original halt lock.
+	db := s.store.DB(name)
+	if err != nil {
+		Error(w, r, fmt.Errorf("database not found: %q", name), http.StatusNotFound)
+		return
+	}
+
+	db.ReleaseHaltLock(r.Context(), lockID)
+
+	/*
+		// Checkpoint WAL so we can apply changes directly to the DB.
+		if err := db.CheckpointNoLock(r.Context()); err != nil {
+			Error(w, r, fmt.Errorf("checkpoint: %w", err), http.StatusInternalServerError)
+			return
+		}
+	*/
+}
+
+func (s *Server) handlePostTx(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	name := q.Get("name")
+
+	// Cannot issue remote halt lock from this node.
+	if id := r.Header.Get("Litefs-Id"); id == s.store.ID() {
+		Error(w, r, fmt.Errorf("cannot remotely halt self"), http.StatusBadRequest)
+		return
+	}
+
+	// Ensure database should already exist from halt lock.
+	db := s.store.DB(name)
+	if db == nil {
+		Error(w, r, fmt.Errorf("database not found: %q", name), http.StatusNotFound)
+		return
+	}
+
+	/*
+		// Checkpoint WAL so we can apply changes directly to the DB.
+		if err := db.CheckpointNoLock(r.Context()); err != nil {
+			Error(w, r, fmt.Errorf("checkpoint: %w", err), http.StatusInternalServerError)
+			return
+		}
+	*/
+
+	// TODO(fwd): Ensure halt lock is held by caller.
+	// TODO(fwd): Prevent halt lock release during copy & apply.
+
+	// Wrap request body in a chunked reader.
+	ltxPath, err := db.WriteLTXFileAt(r.Context(), r.Body)
+	if err != nil {
+		Error(w, r, fmt.Errorf("write ltx file: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Apply transaction to database.
+	if err := db.ApplyLTXNoLock(r.Context(), ltxPath); err != nil {
+		Error(w, r, fmt.Errorf("cannot apply ltx: %s", err), http.StatusInternalServerError)
 		return
 	}
 }
@@ -391,7 +527,7 @@ func (s *Server) streamLTXSnapshot(ctx context.Context, w http.ResponseWriter, d
 }
 
 func Error(w http.ResponseWriter, r *http.Request, err error, code int) {
-	log.Printf("http: error: %s", err)
+	log.Printf("http: %s %s: error: %s", r.Method, r.URL.Path, err)
 	http.Error(w, err.Error(), code)
 }
 

--- a/litefs.go
+++ b/litefs.go
@@ -169,7 +169,7 @@ type posJSON struct {
 // Client represents a client for connecting to other LiteFS nodes.
 type Client interface {
 	// AcquireHaltLock attempts to acquire a remote halt lock on the primary node.
-	AcquireHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string) (*HaltLock, error)
+	AcquireHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) (*HaltLock, error)
 
 	// ReleaseHaltLock releases a previous held remote halt lock on the primary node.
 	ReleaseHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) error

--- a/litefs.go
+++ b/litefs.go
@@ -87,12 +87,13 @@ const (
 	FileTypeWAL
 	FileTypeSHM
 	FileTypePos
+	FileTypeLock
 )
 
 // IsValid returns true if t is a valid file type.
 func (t FileType) IsValid() bool {
 	switch t {
-	case FileTypeDatabase, FileTypeJournal, FileTypeWAL, FileTypeSHM, FileTypePos:
+	case FileTypeDatabase, FileTypeJournal, FileTypeWAL, FileTypeSHM, FileTypePos, FileTypeLock:
 		return true
 	default:
 		return false

--- a/litefs_test.go
+++ b/litefs_test.go
@@ -2,6 +2,7 @@ package litefs_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -44,6 +45,30 @@ func TestPos_IsZero(t *testing.T) {
 		t.Fatal("expected false")
 	} else if (litefs.Pos{PostApplyChecksum: 100}).IsZero() {
 		t.Fatal("expected false")
+	}
+}
+
+func TestPos_MarshalJSON(t *testing.T) {
+	type T struct {
+		Pos litefs.Pos
+	}
+	if data, err := json.Marshal(T{Pos: litefs.Pos{TXID: 1234, PostApplyChecksum: 100}}); err != nil {
+		t.Fatal(err)
+	} else if got, want := string(data), `{"Pos":{"txid":"00000000000004d2","postApplyChecksum":"0000000000000064"}}`; got != want {
+		t.Fatalf("Marshal=%s, want %s", got, want)
+	}
+}
+
+func TestPos_UnmarshalJSON(t *testing.T) {
+	var v struct {
+		Pos litefs.Pos
+	}
+
+	data := []byte(`{"Pos":{"txid":"00000000000004d2","postApplyChecksum":"0000000000000064"}}`)
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatal(err)
+	} else if got, want := v.Pos, (litefs.Pos{TXID: 1234, PostApplyChecksum: 100}); got != want {
+		t.Fatalf("Unmarshal=%s, want %s", got, want)
 	}
 }
 

--- a/mock/client.go
+++ b/mock/client.go
@@ -10,18 +10,18 @@ import (
 var _ litefs.Client = (*Client)(nil)
 
 type Client struct {
-	AcquireHaltLockFunc func(ctx context.Context, primaryURL string, nodeID uint64, name string) (*litefs.HaltLock, error)
-	ReleaseHaltLockFunc func(ctx context.Context, primaryURL string, nodeID uint64, name string, id int64) error
+	AcquireHaltLockFunc func(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) (*litefs.HaltLock, error)
+	ReleaseHaltLockFunc func(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) error
 	CommitFunc          func(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64, r io.Reader) error
 	StreamFunc          func(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]litefs.Pos) (io.ReadCloser, error)
 }
 
-func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string) (*litefs.HaltLock, error) {
-	return c.AcquireHaltLockFunc(ctx, primaryURL, nodeID, name)
+func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) (*litefs.HaltLock, error) {
+	return c.AcquireHaltLockFunc(ctx, primaryURL, nodeID, name, lockID)
 }
 
-func (c *Client) ReleaseHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string, id int64) error {
-	return c.ReleaseHaltLockFunc(ctx, primaryURL, nodeID, name, id)
+func (c *Client) ReleaseHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) error {
+	return c.ReleaseHaltLockFunc(ctx, primaryURL, nodeID, name, lockID)
 }
 
 func (c *Client) Commit(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64, r io.Reader) error {

--- a/mock/client.go
+++ b/mock/client.go
@@ -7,10 +7,27 @@ import (
 	"github.com/superfly/litefs"
 )
 
+var _ litefs.Client = (*Client)(nil)
+
 type Client struct {
-	StreamFunc func(ctx context.Context, rawurl string, id string, posMap map[string]litefs.Pos) (io.ReadCloser, error)
+	AcquireHaltLockFunc func(ctx context.Context, primaryURL string, nodeID, name string) (*litefs.HaltLock, error)
+	ReleaseHaltLockFunc func(ctx context.Context, primaryURL string, nodeID, name string, id int64) error
+	CommitFunc          func(ctx context.Context, primaryURL string, nodeID, name string, lockID int64, r io.Reader) error
+	StreamFunc          func(ctx context.Context, primaryURL string, id string, posMap map[string]litefs.Pos) (io.ReadCloser, error)
 }
 
-func (c *Client) Stream(ctx context.Context, rawurl string, id string, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
-	return c.StreamFunc(ctx, rawurl, id, posMap)
+func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID, name string) (*litefs.HaltLock, error) {
+	return c.AcquireHaltLockFunc(ctx, primaryURL, nodeID, name)
+}
+
+func (c *Client) ReleaseHaltLock(ctx context.Context, primaryURL string, nodeID, name string, id int64) error {
+	return c.ReleaseHaltLockFunc(ctx, primaryURL, nodeID, name, id)
+}
+
+func (c *Client) Commit(ctx context.Context, primaryURL string, nodeID, name string, lockID int64, r io.Reader) error {
+	return c.CommitFunc(ctx, primaryURL, nodeID, name, lockID, r)
+}
+
+func (c *Client) Stream(ctx context.Context, primaryURL string, id string, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
+	return c.StreamFunc(ctx, primaryURL, id, posMap)
 }

--- a/mock/client.go
+++ b/mock/client.go
@@ -10,24 +10,24 @@ import (
 var _ litefs.Client = (*Client)(nil)
 
 type Client struct {
-	AcquireHaltLockFunc func(ctx context.Context, primaryURL string, nodeID, name string) (*litefs.HaltLock, error)
-	ReleaseHaltLockFunc func(ctx context.Context, primaryURL string, nodeID, name string, id int64) error
-	CommitFunc          func(ctx context.Context, primaryURL string, nodeID, name string, lockID int64, r io.Reader) error
-	StreamFunc          func(ctx context.Context, primaryURL string, id string, posMap map[string]litefs.Pos) (io.ReadCloser, error)
+	AcquireHaltLockFunc func(ctx context.Context, primaryURL string, nodeID uint64, name string) (*litefs.HaltLock, error)
+	ReleaseHaltLockFunc func(ctx context.Context, primaryURL string, nodeID uint64, name string, id int64) error
+	CommitFunc          func(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64, r io.Reader) error
+	StreamFunc          func(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]litefs.Pos) (io.ReadCloser, error)
 }
 
-func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID, name string) (*litefs.HaltLock, error) {
+func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string) (*litefs.HaltLock, error) {
 	return c.AcquireHaltLockFunc(ctx, primaryURL, nodeID, name)
 }
 
-func (c *Client) ReleaseHaltLock(ctx context.Context, primaryURL string, nodeID, name string, id int64) error {
+func (c *Client) ReleaseHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string, id int64) error {
 	return c.ReleaseHaltLockFunc(ctx, primaryURL, nodeID, name, id)
 }
 
-func (c *Client) Commit(ctx context.Context, primaryURL string, nodeID, name string, lockID int64, r io.Reader) error {
+func (c *Client) Commit(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64, r io.Reader) error {
 	return c.CommitFunc(ctx, primaryURL, nodeID, name, lockID, r)
 }
 
-func (c *Client) Stream(ctx context.Context, primaryURL string, id string, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
-	return c.StreamFunc(ctx, primaryURL, id, posMap)
+func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
+	return c.StreamFunc(ctx, primaryURL, nodeID, posMap)
 }

--- a/rwmutex.go
+++ b/rwmutex.go
@@ -73,7 +73,7 @@ func (g *RWMutexGuard) Lock(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return context.Cause(ctx)
 		case <-ticker.C:
 			if g.TryLock() {
 				return nil
@@ -158,7 +158,7 @@ func (g *RWMutexGuard) RLock(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return context.Cause(ctx)
 		case <-ticker.C:
 			if g.TryRLock() {
 				return nil

--- a/store.go
+++ b/store.go
@@ -121,6 +121,7 @@ func NewStore(path string, candidate bool) *Store {
 		Retention:                DefaultRetention,
 		RetentionMonitorInterval: DefaultRetentionMonitorInterval,
 
+		HaltLockTTL:             DefaultHaltLockTTL,
 		HaltLockMonitorInterval: DefaultHaltLockMonitorInterval,
 	}
 	s.ctx, s.cancel = context.WithCancelCause(context.Background())

--- a/store.go
+++ b/store.go
@@ -281,6 +281,9 @@ func (s *Store) Close() (retErr error) {
 		if haltLock == nil {
 			continue
 		}
+
+		log.Printf("releasing halt lock on %q", db.Name())
+
 		if err := db.ReleaseRemoteHaltLock(context.Background(), haltLock.ID); err != nil {
 			log.Printf("cannot release halt lock on %q on shutdown", db.Name())
 		}

--- a/store_test.go
+++ b/store_test.go
@@ -169,10 +169,8 @@ func TestStore_ID(t *testing.T) {
 	}
 
 	id := store.ID()
-	if id == "" {
+	if id == 0 {
 		t.Fatal("expected id")
-	} else if got, want := len(id), litefs.IDLength; got != want {
-		t.Fatalf("len(id)=%d, want %d", got, want)
 	}
 
 	// Reopen as a new instance.
@@ -185,7 +183,7 @@ func TestStore_ID(t *testing.T) {
 
 	// Ensure ID is the same.
 	if got, want := store.ID(), id; got != want {
-		t.Fatalf("id=%q, want %q", got, want)
+		t.Fatalf("id=%d, want %d", got, want)
 	}
 }
 
@@ -225,7 +223,7 @@ func TestStore_PrimaryCtx(t *testing.T) {
 		}
 
 		client := mock.Client{
-			StreamFunc: func(ctx context.Context, rawurl string, id string, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
+			StreamFunc: func(ctx context.Context, rawurl string, nodeID uint64, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
 				return io.NopCloser(&bytes.Buffer{}), nil
 			},
 		}
@@ -255,7 +253,7 @@ func TestStore_PrimaryCtx(t *testing.T) {
 	t.Run("InitialReplica", func(t *testing.T) {
 		leaser := litefs.NewStaticLeaser(false, "localhost", "http://localhost:20202")
 		client := mock.Client{
-			StreamFunc: func(ctx context.Context, rawurl string, id string, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
+			StreamFunc: func(ctx context.Context, rawurl string, nodeID uint64, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
 				var buf bytes.Buffer
 				if err := litefs.WriteStreamFrame(&buf, &litefs.ReadyStreamFrame{}); err != nil {
 					return nil, err


### PR DESCRIPTION
## Overview

This pull request implements write forwarding ~~for WAL mode only~~. With write forwarding, any node can write to the database by borrowing the write lock from the primary, catching up, performing the transaction, and then shipping the changeset LTX file back to the primary. The transaction is then propagated out to the other replicas just like any other transaction.

Write forwarding is useful for infrequent writes and this should not be used for regular, write-heavy usage. The main use case for this is being able to run migration scripts from any node. This is useful because deployments can roll over nodes in an unexpected order so we want to run on the first node deployed regardless of its primary state.

Fixes #56 

## Performance 

Please note that the SQLite write lock is held for 1 round trip plus the time it takes to execute the transaction on the replica. This means that performing a forwarded write from Chennai when the primary is in Denver could mean that the write lock is held for ~250ms which would limit your write throughput to only 4 writes per second.

If you use forwarding for regular write usage, such as for a background jobs instance, ensure the node(s) are in the same region as the primary. For example, you can set your candidacy to only your Denver nodes by setting it in the `litefs.yml`:

```yml
lease:
  candidate: ${FLY_REGION == "den"}
```

## TODO

- [x] Refactor duplicate "apply LTX" code
- [x] Add test for gracefully failing when using the rollback journal.
- [x] Add failure test for when serializability is broken
- [x] Add tests for heavy read/write load
- [x] Add tests for failure scenarios