### PR TITLE
Allow proxy passthrough list

### DIFF
--- a/cmd/litefs/etc/litefs.yml
+++ b/cmd/litefs/etc/litefs.yml
@@ -73,6 +73,11 @@ proxy:
   # If true, enables verbose logging of requests by the proxy.
   debug: false
 
+  # List of paths that are ignored by the proxy. The asterisk is
+  # the only available wildcard. These requests are passed
+  # through to the target as-is.
+  passthrough: ["/debug/*", "*.png"]
+
 # The lease section defines how LiteFS creates a cluster and
 # implements leader election. For dynamic clusters, use the
 # "consul". This allows the primary to change automatically when

--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -221,10 +221,11 @@ type HTTPConfig struct {
 
 // ProxyConfig represents the configuration for the HTTP proxy server.
 type ProxyConfig struct {
-	Addr   string `yaml:"addr"`
-	Target string `yaml:"target"`
-	DB     string `yaml:"db"`
-	Debug  bool   `yaml:"debug"`
+	Addr        string   `yaml:"addr"`
+	Target      string   `yaml:"target"`
+	DB          string   `yaml:"db"`
+	Debug       bool     `yaml:"debug"`
+	Passthrough []string `yaml:"passthrough"`
 }
 
 // LeaseConfig represents a generic configuration for all lease types.

--- a/http/http.go
+++ b/http/http.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/superfly/litefs"
 )
@@ -77,4 +79,18 @@ func WritePosMapTo(w io.Writer, m map[string]litefs.Pos) error {
 	}
 
 	return nil
+}
+
+// CompileMatch returns a regular expression on a simple asterisk-only wildcard.
+func CompileMatch(s string) (*regexp.Regexp, error) {
+	// Convert any special characters to literal matches.
+	s = regexp.QuoteMeta(s)
+
+	// Convert escaped asterisks to wildcard matches.
+	s = strings.ReplaceAll(s, `\*`, ".*")
+
+	// Match to beginning & end of path.
+	s = "^" + s + "$"
+
+	return regexp.Compile(s)
 }

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -1,0 +1,38 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/superfly/litefs/http"
+)
+
+func TestCompileMatch(t *testing.T) {
+	for _, tt := range []struct {
+		expr    string
+		str     string
+		matches bool
+	}{
+		{"/build/*", "/build", false},
+		{"/build/*", "/build/", true},
+		{"/build/*", "/build/foo", true},
+		{"/build/*", "/build/foo/bar", true},
+		{"*.png", "/images/pic.png", true},
+		{"*foo*", "/foo", true},
+		{"*foo*", "foo/bar", true},
+		{"*foo*", "/foo/bar", true},
+		{"*foo*", "/bar/baz", false},
+	} {
+		t.Run("", func(t *testing.T) {
+			re, err := http.CompileMatch(tt.expr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			matched := re.MatchString(tt.str)
+			if tt.matches && !matched {
+				t.Fatalf("expected %q to match %q, but didn't", tt.expr, tt.str)
+			} else if !tt.matches && matched {
+				t.Fatalf("expected %q to not match %q, but did", tt.expr, tt.str)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request allows users to configure the proxy to ignore certain URL paths. The pattern format only allows an asterisk as a wildcard. For example, `/assets/*` would match all URLs with a `/assets/` path prefix. It would not, however, match `/assets`. This can be used for matching suffixes (e.g. `*.png`) and infixes (`*foo*`) as well.

Fixes #275 

## Usage

The `litefs.yml` config file now has a `proxy.passthrough` field:

```yml
proxy:
  addr:   ":8080"
  target: "localhost:8081"
  db:     "my.db"
  passthrough: 
    - "/debug*"
    - "*.png"
```

or you can use the JSON array syntax:

```yml
proxy:
  addr:   ":8080"
  target: "localhost:8081"
  db:     "my.db"
  passthrough: ["/debug/*", "*.png"]
```
