### PR TITLE
Enable FUSE ExplicitInvalidateData flag

### DIFF
--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -70,6 +70,7 @@ func (fsys *FileSystem) Mount() (err error) {
 	options := []fuse.MountOption{
 		fuse.FSName("litefs"),
 		fuse.LockingPOSIX(),
+		fuse.ExplicitInvalidateData(),
 	}
 	if fsys.AllowOther {
 		options = append(options, fuse.AllowOther())


### PR DESCRIPTION
This fixes an issue where changing the database size invalidates all the pages from the OS page cache.

Fixes https://github.com/superfly/litefs/issues/149