### PR TITLE
Stop proxy server on startup error

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -110,6 +110,14 @@ func runMount(ctx context.Context, args []string) error {
 			_ = c.Close()
 			os.Exit(1)
 		}
+
+		// Ensure proxy server is closed on error. Otherwise it can be in a
+		// state where it is accepting connections but not processing them.
+		// See: https://github.com/superfly/litefs/pull/278#issuecomment-1419460935
+		if c.ProxyServer != nil {
+			log.Printf("closing proxy server on startup error")
+			_ = c.ProxyServer.Close()
+		}
 	}
 
 	fmt.Println("waiting for signal or subprocess to exit")


### PR DESCRIPTION
This pull request changes the startup behavior when there is an error and `exit-on-error` is `false`. Previously, the proxy server could have begun listening on the proxy port but the error could have occurred before the proxy had begun processing incoming requests. In this case, proxied requests would simply hang.

Now, the proxy server's listener is closed if there is a startup error so it is clear that the server is down. An alternative would have been to continue trying to start the proxy server but if there's a startup error then that the request would simply have errored in a different place.

Original post: https://github.com/superfly/litefs/pull/278#issuecomment-1419463845