### PR TITLE
Add 'export' command

### DIFF
--- a/cmd/litefs/export.go
+++ b/cmd/litefs/export.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/superfly/litefs/http"
+	"github.com/superfly/litefs/internal"
+)
+
+// ExportCommand represents a command to export a database from the cluster.
+type ExportCommand struct {
+	// Target LiteFS URL
+	URL string
+
+	// Name of database on LiteFS cluster.
+	Name string
+
+	// Path to export the database to.
+	Path string
+}
+
+// NewExportCommand returns a new instance of ExportCommand.
+func NewExportCommand() *ExportCommand {
+	return &ExportCommand{
+		URL: DefaultURL,
+	}
+}
+
+// ParseFlags parses the command line flags & config file.
+func (c *ExportCommand) ParseFlags(ctx context.Context, args []string) (err error) {
+	fs := flag.NewFlagSet("litefs-export", flag.ContinueOnError)
+	fs.StringVar(&c.URL, "url", "http://localhost:20202", "LiteFS API URL")
+	fs.StringVar(&c.Name, "name", "", "database name")
+	fs.Usage = func() {
+		fmt.Println(`
+The export command will download a SQLite database from a LiteFS cluster. If the
+database doesn't exist then an error will be returned.
+
+Usage:
+
+	litefs export [arguments] PATH
+
+Arguments:
+`[1:])
+		fs.PrintDefaults()
+		fmt.Println("")
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if fs.NArg() == 0 {
+		fs.Usage()
+		return flag.ErrHelp
+	} else if fs.NArg() > 1 {
+		return fmt.Errorf("too many arguments")
+	}
+
+	// Copy first arg as database path.
+	c.Path = fs.Arg(0)
+
+	return nil
+}
+
+// Run executes the command.
+func (c *ExportCommand) Run(ctx context.Context) (err error) {
+	// Clear existing database and related files.
+	for _, suffix := range []string{"", "-journal", "-wal", "-shm"} {
+		if err := os.Remove(c.Path + suffix); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	tmpPath := c.Path + ".tmp"
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	t := time.Now()
+
+	// Fetch snapshot from the server.
+	client := http.NewClient()
+	r, err := client.Export(ctx, c.URL, c.Name)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = r.Close() }()
+
+	// Copy bytes to temp file.
+	if _, err := io.Copy(f, r); err != nil {
+		return err
+	} else if err := r.Close(); err != nil {
+		return err
+	}
+
+	// Sync & close file.
+	if err := f.Sync(); err != nil {
+		return err
+	} else if err := f.Close(); err != nil {
+		return err
+	}
+
+	// Atomically rename & sync parent directory.
+	if err := os.Rename(tmpPath, c.Path); err != nil {
+		return err
+	} else if err := internal.Sync(filepath.Dir(c.Path)); err != nil {
+		return err
+	}
+
+	// Notify user of success and elapsed time.
+	fmt.Printf("Export of database %q in %s\n", c.Name, time.Since(t))
+
+	return nil
+}

--- a/cmd/litefs/export_test.go
+++ b/cmd/litefs/export_test.go
@@ -1,0 +1,62 @@
+package main_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/superfly/litefs"
+	main "github.com/superfly/litefs/cmd/litefs"
+	"github.com/superfly/litefs/internal/testingutil"
+)
+
+// Ensure a database can be exported from a LiteFS server.
+func TestExportCommand(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		m0 := runMountCommand(t, newMountCommand(t, t.TempDir(), nil))
+		waitForPrimary(t, m0)
+
+		// Create database on LiteFS.
+		db := testingutil.OpenSQLDB(t, filepath.Join(m0.Config.FUSE.Dir, "my.db"))
+		if _, err := db.Exec(`CREATE TABLE t (x)`); err != nil {
+			t.Fatal(err)
+		} else if _, err := db.Exec(`INSERT INTO t VALUES (100)`); err != nil {
+			t.Fatal(err)
+		} else if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Export database from LiteFS.
+		dsn := filepath.Join(t.TempDir(), "db")
+		cmd := main.NewExportCommand()
+		cmd.URL = m0.HTTPServer.URL()
+		cmd.Name = "my.db"
+		cmd.Path = dsn
+		if err := cmd.Run(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Read from exported database.
+		db = testingutil.OpenSQLDB(t, dsn)
+		var x int
+		if err := db.QueryRow(`SELECT x FROM t`).Scan(&x); err != nil {
+			t.Fatal(err)
+		} else if got, want := x, 100; got != want {
+			t.Fatalf("x=%d, want %d", got, want)
+		}
+	})
+
+	t.Run("ErrDatabaseNotFound", func(t *testing.T) {
+		m0 := runMountCommand(t, newMountCommand(t, t.TempDir(), nil))
+		waitForPrimary(t, m0)
+
+		// Export missing database from LiteFS.
+		cmd := main.NewExportCommand()
+		cmd.URL = m0.HTTPServer.URL()
+		cmd.Name = "nosuchdatabase"
+		cmd.Path = filepath.Join(t.TempDir(), "db")
+		if err := cmd.Run(context.Background()); err == nil || err != litefs.ErrDatabaseNotFound {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -49,6 +49,13 @@ func run(ctx context.Context, args []string) error {
 	}
 
 	switch cmd {
+	case "export":
+		c := NewExportCommand()
+		if err := c.ParseFlags(ctx, args); err != nil {
+			return err
+		}
+		return c.Run(ctx)
+
 	case "import":
 		c := NewImportCommand()
 		if err := c.ParseFlags(ctx, args); err != nil {


### PR DESCRIPTION
This pull request adds a `litefs export` command for downloading a point-in-time snapshot of the database. It is safe to use on a live cluster. This approach is significantly faster than using `VACUUM INTO` or `.backup` since it avoids any FUSE overhead.

## Usage

```
# Download from local LiteFS node
$ litefs -name my.db /path/to/exported.db
```

```
# Download from remote LiteFS node
$ litefs -url http://$HOSTNAME:20202 -name my.db /path/to/exported.db
```
