### PR TITLE
Implement drop database

### DIFF
--- a/fuse/journal_node.go
+++ b/fuse/journal_node.go
@@ -51,7 +51,9 @@ func (n *JournalNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fus
 	resp.Flags |= fuse.OpenKeepCache
 
 	f, err := n.db.OpenJournal(ctx)
-	if err != nil {
+	if os.IsNotExist(err) {
+		return nil, syscall.ENOENT
+	} else if err != nil {
 		return nil, err
 	}
 	return newJournalHandle(n, f), nil


### PR DESCRIPTION
This pull request implements `Remove()` in the FUSE API so that databases can be deleted. This deletion also removes any associated files (`-journal`, `-wal, `-shm`, `-pos`, & `-lock`) and propagates the change down to the replica. The database can later be recreated but the position will restart from TXID 1.

Fixes https://github.com/superfly/litefs/issues/257