### PR TITLE
Add 'run' command

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -66,6 +66,13 @@ func run(ctx context.Context, args []string) error {
 	case "mount":
 		return runMount(ctx, args)
 
+	case "run":
+		c := NewRunCommand()
+		if err := c.ParseFlags(ctx, args); err != nil {
+			return err
+		}
+		return c.Run(ctx)
+
 	case "version":
 		fmt.Println(VersionString())
 		return nil
@@ -377,8 +384,10 @@ Usage:
 
 The commands are:
 
+	export       export a database from a LiteFS cluster to disk
 	import       import a SQLite database into a LiteFS cluster
 	mount        mount the LiteFS FUSE file system
+	run          executes a subcommand for remote writes
 	version      prints the version
 `[1:])
 }

--- a/cmd/litefs/run.go
+++ b/cmd/litefs/run.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	litefsgo "github.com/superfly/litefs-go"
+)
+
+// RunCommand represents a command to run a program with the HALT lock.
+type RunCommand struct {
+	// The database to acquire a halt lock on.
+	WithHaltLockOn string
+
+	// Subcommand & args
+	Cmd  string
+	Args []string
+
+	// If true, enables verbose logging.
+	Verbose bool
+}
+
+// NewRunCommand returns a new instance of RunCommand.
+func NewRunCommand() *RunCommand {
+	return &RunCommand{}
+}
+
+// ParseFlags parses the command line flags & config file.
+func (c *RunCommand) ParseFlags(ctx context.Context, args []string) (err error) {
+	// Split the args list if there is a double dash arg included.
+	args0, args1 := splitArgs(args)
+
+	fs := flag.NewFlagSet("litefs-run", flag.ContinueOnError)
+	fs.StringVar(&c.WithHaltLockOn, "with-halt-lock-on", "", "full database path to halt")
+	fs.BoolVar(&c.Verbose, "v", false, "enable verbose logging")
+	fs.Usage = func() {
+		fmt.Println(`
+The run command will execute a subcommand with certain guarantees provided by
+LiteFS. Typically, this is executed with --with-halt-lock-on to acquire a HALT lock
+so that write transactions can temporarily be executed on the local node.
+
+Usage:
+
+	litefs run [arguments] -- CMD [ARG...]
+
+Arguments:
+`[1:])
+		fs.PrintDefaults()
+		fmt.Println("")
+	}
+	if err := fs.Parse(args0); err != nil {
+		return err
+	} else if fs.NArg() == 0 && len(args1) == 0 {
+		fs.Usage()
+		return flag.ErrHelp
+	} else if fs.NArg() > 0 {
+		return fmt.Errorf("too many arguments, specify a '--' to specify an exec command")
+	}
+
+	if len(args1) == 0 {
+		return fmt.Errorf("no subcommand specified")
+	}
+	c.Cmd, c.Args = args1[0], args1[1:]
+
+	// Optionally disable logging.
+	if !c.Verbose {
+		log.SetOutput(io.Discard)
+	}
+
+	return nil
+}
+
+// Run executes the command.
+func (c *RunCommand) Run(ctx context.Context) (err error) {
+	// Acquire the halt lock on the given database, if specified.
+	var f *os.File
+	if c.WithHaltLockOn != "" {
+		// Ensure database exists first.
+		if _, err := os.Stat(c.WithHaltLockOn); os.IsNotExist(err) {
+			return fmt.Errorf("database does not exist: %s", c.WithHaltLockOn)
+		} else if err != nil {
+			return err
+		}
+
+		// Attempt to lock the database.
+		if f, err = os.OpenFile(c.WithHaltLockOn+"-lock", os.O_RDWR, 0666); os.IsNotExist(err) {
+			return fmt.Errorf("lock file not available, are you sure %q is a LiteFS mount?", filepath.Dir(c.WithHaltLockOn))
+		} else if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+
+		t := time.Now()
+		log.Printf("acquiring halt lock")
+		if err := litefsgo.Halt(f); err != nil {
+			return err
+		}
+		log.Printf("halt lock acquired in %s", time.Since(t))
+	}
+
+	// Execute subcommand.
+	cmd := exec.CommandContext(ctx, c.Cmd, c.Args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if f != nil {
+		cmd.ExtraFiles = []*os.File{f} // pass along, otherwise the file is flushed
+	}
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	// Unhalt, if database specified.
+	if f != nil {
+		t := time.Now()
+		log.Printf("releasing halt lock")
+		if err := litefsgo.Unhalt(f); err != nil {
+			return err
+		}
+		log.Printf("halt lock released in %s", time.Since(t))
+
+		if err := f.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This pull request adds the `litefs run` command which executes a subcommand with certain guarantees from LiteFS. Currently, this is just used to acquire and release the `HALT` lock during execution but other options (such as promotion) may be done in the future.

## Usage

Execute a `CREATE TABLE` while the local node holds the `HALT` lock. This enables write forwarding for migrations.

```sh
$ litefs run -with-halt-lock-on /litefs/db -- sqlite3 /litefs/db "CREATE TABLE t (x TEXT)"
```

