### PR TITLE
Ensure WAL is truncated to original size on CommitWAL() failure

### DIFF
--- a/store.go
+++ b/store.go
@@ -34,11 +34,9 @@ const (
 	DefaultRetention                = 10 * time.Minute
 	DefaultRetentionMonitorInterval = 1 * time.Minute
 
-	DefaultHaltAcquireTimeout      = 5 * time.Second
+	DefaultHaltAcquireTimeout      = 10 * time.Second
 	DefaultHaltLockTTL             = 30 * time.Second
 	DefaultHaltLockMonitorInterval = 5 * time.Second
-
-	DefaultBeginTimeout = 30 * time.Second
 )
 
 var ErrStoreClosed = fmt.Errorf("store closed")
@@ -84,15 +82,12 @@ type Store struct {
 	Retention                time.Duration
 	RetentionMonitorInterval time.Duration
 
-	// Time to wait to acquire the write lock after acquiring the HALT.
-	HaltAcquireTimeout time.Duration
-
 	// Max time to hold HALT lock and interval between expiration checks.
 	HaltLockTTL             time.Duration
 	HaltLockMonitorInterval time.Duration
 
-	// Transaction timeouts.
-	BeginTimeout time.Duration
+	// Time to wait to acquire the HALT lock.
+	HaltAcquireTimeout time.Duration
 
 	// Callback to notify kernel of file changes.
 	Invalidator Invalidator


### PR DESCRIPTION
This pull request rolls back WAL changes if any error occurs in `CommitWAL()`. This is to ensure the WAL & LTX files are kept in sync. If the WAL cannot be truncated, the process must panic and it will fix itself on recovery after restart. This problem is particularly noticeable in write forwarding if the primary dies while a halt lock is held by a replica.