### PR TITLE
Implement primary handoff

### DIFF
--- a/db.go
+++ b/db.go
@@ -1677,6 +1677,11 @@ func (db *DB) CommitWAL(ctx context.Context) (err error) {
 		return fmt.Errorf("close ltx file: %s", err)
 	}
 
+	// Ensure node is still writable before final commit step.
+	if !db.Writeable() {
+		return fmt.Errorf("node lost write access during transaction, rolling back")
+	}
+
 	// Atomically rename the file
 	if err := os.Rename(tmpPath, ltxPath); err != nil {
 		return fmt.Errorf("rename ltx file: %w", err)

--- a/lease.go
+++ b/lease.go
@@ -2,6 +2,7 @@ package litefs
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 )
@@ -15,6 +16,10 @@ type Leaser interface {
 	// Acquire attempts to acquire the lease to become the primary.
 	Acquire(ctx context.Context) (Lease, error)
 
+	// AcquireExisting returns a lease from an existing lease ID.
+	// This occurs when the primary is handed off to a replica node.
+	AcquireExisting(ctx context.Context, leaseID string) (Lease, error)
+
 	// PrimaryInfo attempts to read the current primary data.
 	// Returns ErrNoPrimary if no primary currently has the lease.
 	PrimaryInfo(ctx context.Context) (PrimaryInfo, error)
@@ -22,12 +27,18 @@ type Leaser interface {
 
 // Lease represents an acquired lease from a Leaser.
 type Lease interface {
+	ID() string
 	RenewedAt() time.Time
 	TTL() time.Duration
 
 	// Renew attempts to reset the TTL on the lease.
 	// Returns ErrLeaseExpired if the lease has expired or was deleted.
 	Renew(ctx context.Context) error
+
+	// Marks the lease as handed-off to another node.
+	// This should send the nodeID to the channel returned by HandoffCh().
+	Handoff(nodeID uint64) error
+	HandoffCh() <-chan uint64
 
 	// Close attempts to remove the lease from the server.
 	Close() error
@@ -85,6 +96,11 @@ func (l *StaticLeaser) Acquire(ctx context.Context) (Lease, error) {
 	return &StaticLease{leaser: l}, nil
 }
 
+// AcquireExisting always returns an error. Static leasing does not support handoff.
+func (l *StaticLeaser) AcquireExisting(ctx context.Context, leaseID string) (Lease, error) {
+	return nil, fmt.Errorf("static lease handoff not supported")
+}
+
 // PrimaryInfo returns the primary's info.
 // Returns ErrNoPrimary if the node is the primary.
 func (l *StaticLeaser) PrimaryInfo(ctx context.Context) (PrimaryInfo, error) {
@@ -109,6 +125,9 @@ type StaticLease struct {
 	leaser *StaticLeaser
 }
 
+// ID always returns a blank string.
+func (l *StaticLease) ID() string { return "" }
+
 // RenewedAt returns the Unix epoch in UTC.
 func (l *StaticLease) RenewedAt() time.Time { return time.Unix(0, 0).UTC() }
 
@@ -117,6 +136,14 @@ func (l *StaticLease) TTL() time.Duration { return staticLeaseExpiresAt.Sub(l.Re
 
 // Renew is a no-op.
 func (l *StaticLease) Renew(ctx context.Context) error { return nil }
+
+// Handoff always returns an error.
+func (l *StaticLease) Handoff(nodeID uint64) error {
+	return fmt.Errorf("static lease does not support handoff")
+}
+
+// HandoffCh always returns a nil channel.
+func (l *StaticLease) HandoffCh() <-chan uint64 { return nil }
 
 func (l *StaticLease) Close() error { return nil }
 

--- a/mock/lease.go
+++ b/mock/lease.go
@@ -10,10 +10,11 @@ import (
 var _ litefs.Leaser = (*Leaser)(nil)
 
 type Leaser struct {
-	CloseFunc        func() error
-	AdvertiseURLFunc func() string
-	AcquireFunc      func(ctx context.Context) (litefs.Lease, error)
-	PrimaryInfoFunc  func(ctx context.Context) (litefs.PrimaryInfo, error)
+	CloseFunc           func() error
+	AdvertiseURLFunc    func() string
+	AcquireFunc         func(ctx context.Context) (litefs.Lease, error)
+	AcquireExistingFunc func(ctx context.Context, leaseID string) (litefs.Lease, error)
+	PrimaryInfoFunc     func(ctx context.Context) (litefs.PrimaryInfo, error)
 }
 
 func (l *Leaser) Close() error {
@@ -28,6 +29,10 @@ func (l *Leaser) Acquire(ctx context.Context) (litefs.Lease, error) {
 	return l.AcquireFunc(ctx)
 }
 
+func (l *Leaser) AcquireExisting(ctx context.Context, leaseID string) (litefs.Lease, error) {
+	return l.AcquireExistingFunc(ctx, leaseID)
+}
+
 func (l *Leaser) PrimaryInfo(ctx context.Context) (litefs.PrimaryInfo, error) {
 	return l.PrimaryInfoFunc(ctx)
 }
@@ -35,10 +40,17 @@ func (l *Leaser) PrimaryInfo(ctx context.Context) (litefs.PrimaryInfo, error) {
 var _ litefs.Lease = (*Lease)(nil)
 
 type Lease struct {
+	IDFunc        func() string
 	RenewedAtFunc func() time.Time
 	TTLFunc       func() time.Duration
 	RenewFunc     func(ctx context.Context) error
+	HandoffFunc   func(nodeID uint64) error
+	HandoffChFunc func() <-chan uint64
 	CloseFunc     func() error
+}
+
+func (l *Lease) ID() string {
+	return l.IDFunc()
 }
 
 func (l *Lease) RenewedAt() time.Time {
@@ -51,6 +63,14 @@ func (l *Lease) TTL() time.Duration {
 
 func (l *Lease) Renew(ctx context.Context) error {
 	return l.RenewFunc(ctx)
+}
+
+func (l *Lease) Handoff(nodeID uint64) error {
+	return l.HandoffFunc(nodeID)
+}
+
+func (l *Lease) HandoffCh() <-chan uint64 {
+	return l.HandoffChFunc()
 }
 
 func (l *Lease) Close() error {

--- a/store_test.go
+++ b/store_test.go
@@ -209,7 +209,8 @@ func TestStore_PrimaryCtx(t *testing.T) {
 				}
 				return nil
 			},
-			CloseFunc: func() error { return nil },
+			HandoffChFunc: func() <-chan uint64 { return nil },
+			CloseFunc:     func() error { return nil },
 		}
 		leaser := mock.Leaser{
 			CloseFunc:        func() error { return nil },


### PR DESCRIPTION
This pull request implements the ability for a primary node to handoff its lease to a designated replica. The replica must be currently connected to the primary for this to work. After the lease ID is handed to the replica's stream, any error that occurs during handoff should cause the cluster to fall back to regular lease expiration handling.

The functionality is only implemented internally via the `litefs.Store.Handoff(nodeID)` function right now. Additional integration testing will be done once manual promotion (#299) is implemented in a separate PR.

Fixes #11 