### PR TITLE
Set path for proxy server cookie

### DIFF
--- a/cmd/litefs/mount_darwin.go
+++ b/cmd/litefs/mount_darwin.go
@@ -5,11 +5,15 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+
+	"github.com/superfly/litefs/http"
 )
 
 // MountCommand represents a command to mount the file system.
 type MountCommand struct {
 	Config Config
+
+	ProxyServer *http.ProxyServer
 }
 
 // NewMountCommand returns a new instance of MountCommand.

--- a/http/proxy_server.go
+++ b/http/proxy_server.go
@@ -251,6 +251,7 @@ func (s *ProxyServer) proxyToTarget(w http.ResponseWriter, r *http.Request, pass
 			http.SetCookie(w, &http.Cookie{
 				Name:     TXIDCookieName,
 				Value:    ltx.FormatTXID(pos.TXID),
+				Path:     "/",
 				Expires:  time.Now().Add(s.CookieExpiry),
 				HttpOnly: true,
 			})


### PR DESCRIPTION
As reported in https://github.com/superfly/litefs/pull/271#issuecomment-1500122333, the `__txid` cookie should be set on the `/` path.