### PR TITLE
Add 'promote' flag to config

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -104,6 +104,10 @@ type LeaseConfig struct {
 	// Replicas in a state lease should set this to false.
 	Candidate bool `yaml:"candidate"`
 
+	// If true & node is a candidate, it will attempt to promote itself
+	// automatically once it connects to the cluster and syncs.
+	Promote bool `yaml:"promote"`
+
 	// After disconnect, time before node tries to reconnect to primary or
 	// becomes primary itself.
 	ReconnectDelay time.Duration `yaml:"reconnect-delay"`


### PR DESCRIPTION
This pull request adds the ability to automatically promote a candidate node after it starts and syncs with the cluster. This is to improve the experience of deploying migrations by always allowing them to run on the local node.

If `lease.promote` is enabled on a node that is not a candidate, it is ignored and a log message is printed. 

## Usage

```yml
lease:
  promote: true
```