### PR TITLE
Allow multiple exec commands

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -21,10 +21,11 @@ import (
 
 // Config represents a configuration for the binary process.
 type Config struct {
-	Exec         string `yaml:"exec"`
-	ExitOnError  bool   `yaml:"exit-on-error"`
-	SkipSync     bool   `yaml:"skip-sync"`
-	StrictVerify bool   `yaml:"strict-verify"`
+	ExitOnError  bool `yaml:"exit-on-error"`
+	SkipSync     bool `yaml:"skip-sync"`
+	StrictVerify bool `yaml:"strict-verify"`
+
+	Exec ExecConfigSlice `yaml:"exec"`
 
 	Data    DataConfig    `yaml:"data"`
 	FUSE    FUSEConfig    `yaml:"fuse"`
@@ -54,6 +55,27 @@ func NewConfig() Config {
 	config.Tracing.Compress = DefaultTracingCompress
 
 	return config
+}
+
+// ExecConfigSlice represents a wrapper type for handling YAML marshaling.
+type ExecConfigSlice []*ExecConfig
+
+func (a *ExecConfigSlice) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Tag {
+	case "!!str":
+		*a = ExecConfigSlice{{Cmd: value.Value}}
+		return nil
+	case "!!seq":
+		return value.Decode((*[]*ExecConfig)(a))
+	default:
+		return fmt.Errorf("invalid exec config format")
+	}
+}
+
+// ExecConfig represents a single exec command.
+type ExecConfig struct {
+	Cmd         string `yaml:"cmd"`
+	IfCandidate bool   `yaml:"if-candidate"`
 }
 
 // DataConfig represents the configuration for internal LiteFS data. This

--- a/cmd/litefs/config_test.go
+++ b/cmd/litefs/config_test.go
@@ -1,0 +1,79 @@
+package main_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	main "github.com/superfly/litefs/cmd/litefs"
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfig(t *testing.T) {
+	t.Run("EmptyExec", func(t *testing.T) {
+		var config main.Config
+		dec := yaml.NewDecoder(strings.NewReader("exec:\n"))
+		dec.KnownFields(true)
+		if err := dec.Decode(&config); err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := len(config.Exec), 0; got != want {
+			t.Fatalf("len=%v, want %v", got, want)
+		}
+	})
+
+	t.Run("InlineExec", func(t *testing.T) {
+		var config main.Config
+		dec := yaml.NewDecoder(strings.NewReader(`exec: "run me"`))
+		dec.KnownFields(true)
+		if err := dec.Decode(&config); err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := config.Exec[0].Cmd, "run me"; got != want {
+			t.Fatalf("Cmd=%q, want %q", got, want)
+		}
+	})
+
+	t.Run("SingleExec", func(t *testing.T) {
+		buf, err := testdata.ReadFile("testdata/config/single_exec.yml")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var config main.Config
+		dec := yaml.NewDecoder(bytes.NewReader(buf))
+		dec.KnownFields(true)
+		if err := dec.Decode(&config); err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := config.Exec[0].Cmd, "run me"; got != want {
+			t.Fatalf("Cmd=%q, want %q", got, want)
+		}
+	})
+
+	t.Run("MultiExec", func(t *testing.T) {
+		buf, err := testdata.ReadFile("testdata/config/multi_exec.yml")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var config main.Config
+		dec := yaml.NewDecoder(bytes.NewReader(buf))
+		dec.KnownFields(true)
+		if err := dec.Decode(&config); err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := config.Exec[0].Cmd, "run me"; got != want {
+			t.Fatalf("Cmd=%q, want %q", got, want)
+		} else if got, want := config.Exec[0].IfCandidate, true; got != want {
+			t.Fatalf("IfCandidate=%v, want %v", got, want)
+		}
+		if got, want := config.Exec[1].Cmd, "run me too"; got != want {
+			t.Fatalf("Cmd=%q, want %q", got, want)
+		}
+	})
+}

--- a/cmd/litefs/export_test.go
+++ b/cmd/litefs/export_test.go
@@ -1,3 +1,4 @@
+// go:build linux
 package main_test
 
 import (

--- a/cmd/litefs/import_test.go
+++ b/cmd/litefs/import_test.go
@@ -1,3 +1,4 @@
+// go:build linux
 package main_test
 
 import (

--- a/cmd/litefs/main_test.go
+++ b/cmd/litefs/main_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"embed"
 	"flag"
 	"log"
 	"os"
@@ -8,6 +9,9 @@ import (
 
 	"github.com/superfly/litefs"
 )
+
+//go:embed testdata
+var testdata embed.FS
 
 var (
 	fuseDebug = flag.Bool("fuse.debug", false, "enable fuse debugging")

--- a/cmd/litefs/testdata/config/multi_exec.yml
+++ b/cmd/litefs/testdata/config/multi_exec.yml
@@ -1,0 +1,5 @@
+exec:
+  - cmd: "run me"
+    if-candidate: true
+
+  - cmd: "run me too"

--- a/cmd/litefs/testdata/config/single_exec.yml
+++ b/cmd/litefs/testdata/config/single_exec.yml
@@ -1,0 +1,2 @@
+exec:
+  - cmd: "run me"


### PR DESCRIPTION
This pull request adds the ability to specify multiple subcommands in the config. This is useful with #306 as it allows a candidate node to promote itself, run migrations, and then run the application server. Commands are run sequentially. The last command is run asynchronously and its exit is sent to the `execCh`. If commands fail, then the LiteFS server will be shutdown.

## Usage

This is an example of a config that only has candidates in a single region and automatically promotes when a new node starts up and syncs. Once promoted, a candidate node will run migrations and then start the app server. For non-candidate nodes, it will simply run the app server.

```yml
exec:
  - cmd: "rails db:migrate"
    if-candidate: true

  - cmd: "rails server"

lease:
  candidate: ${FLY_REGION == PRIMARY_REGION}
  promote: true
```

The original format of `exec` is still supported for people that only need to run a simple command:

```yml
exec: "rails server"
```