### PR TITLE
Backup Client

### DIFF
--- a/backup_client.go
+++ b/backup_client.go
@@ -1,0 +1,258 @@
+package litefs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/superfly/litefs/internal"
+	"github.com/superfly/ltx"
+)
+
+type BackupClient interface {
+	// URL of the backup service.
+	URL() string
+
+	// PosMap returns the replication position for all databases on the backup service.
+	PosMap(ctx context.Context) (map[string]ltx.Pos, error)
+
+	// WriteTx writes an LTX file to the backup service. The file must be
+	// contiguous with the latest LTX file on the backup service or else it
+	// will return an ltx.PosMismatchError.
+	WriteTx(ctx context.Context, name string, r io.Reader) error
+
+	// FetchSnapshot requests a full snapshot of the database as it exists on
+	// the backup service. This should be used if the LiteFS node has become
+	// out of sync with the backup service.
+	FetchSnapshot(ctx context.Context, name string) (io.ReadCloser, error)
+}
+
+var _ BackupClient = (*FileBackupClient)(nil)
+
+// FileBackupClient is a reference implemenation for BackupClient.
+// This implementation is typically only used for testing.
+type FileBackupClient struct {
+	mu   sync.Mutex
+	path string
+}
+
+// NewFileBackupClient returns a new instance of FileBackupClient.
+func NewFileBackupClient(path string) *FileBackupClient {
+	return &FileBackupClient{path: path}
+}
+
+// Open validates & creates the path the client was initialized with.
+func (c *FileBackupClient) Open() (err error) {
+	// Ensure root path exists and we can get the absolute path from it.
+	if c.path == "" {
+		return fmt.Errorf("backup path required")
+	} else if c.path, err = filepath.Abs(c.path); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(c.path, 0777); err != nil {
+		return err
+	}
+	return nil
+}
+
+// URL of the backup service.
+func (c *FileBackupClient) URL() string {
+	return (&url.URL{
+		Scheme: "file",
+		Path:   filepath.ToSlash(c.path),
+	}).String()
+}
+
+// PosMap returns the replication position for all databases on the backup service.
+func (c *FileBackupClient) PosMap(ctx context.Context) (map[string]ltx.Pos, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ents, err := os.ReadDir(c.path)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	m := make(map[string]ltx.Pos)
+	for _, ent := range ents {
+		if !ent.IsDir() {
+			continue
+		}
+		pos, err := c.pos(ctx, ent.Name())
+		if err != nil {
+			return nil, err
+		}
+		m[ent.Name()] = pos
+	}
+
+	return m, nil
+}
+
+// pos returns the replication position for a single database.
+func (c *FileBackupClient) pos(ctx context.Context, name string) (ltx.Pos, error) {
+	dir := filepath.Join(c.path, name)
+	ents, err := os.ReadDir(dir)
+	if err != nil && !os.IsNotExist(err) {
+		return ltx.Pos{}, err
+	}
+
+	var max string
+	for _, ent := range ents {
+		if ent.IsDir() || filepath.Ext(ent.Name()) != ".ltx" {
+			continue
+		}
+		if max == "" || ent.Name() > max {
+			max = ent.Name()
+		}
+	}
+
+	// No LTX files, return empty position.
+	if max == "" {
+		return ltx.Pos{}, nil
+	}
+
+	// Determine position from last file in directory.
+	f, err := os.Open(filepath.Join(dir, max))
+	if err != nil {
+		return ltx.Pos{}, err
+	}
+	defer func() { _ = f.Close() }()
+
+	dec := ltx.NewDecoder(f)
+	if err := dec.Verify(); err != nil {
+		return ltx.Pos{}, err
+	}
+
+	return ltx.Pos{
+		TXID:              dec.Header().MaxTXID,
+		PostApplyChecksum: dec.Trailer().PostApplyChecksum,
+	}, nil
+}
+
+// WriteTx writes an LTX file to the backup service. The file must be
+// contiguous with the latest LTX file on the backup service or else it
+// will return an ltx.PosMismatchError.
+func (c *FileBackupClient) WriteTx(ctx context.Context, name string, r io.Reader) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Determine the current position.
+	pos, err := c.pos(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	// Peek at the LTX header.
+	buf := make([]byte, ltx.HeaderSize)
+	var hdr ltx.Header
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return err
+	} else if err := hdr.UnmarshalBinary(buf); err != nil {
+		return err
+	}
+	r = io.MultiReader(bytes.NewReader(buf), r)
+
+	// Ensure LTX file is contiguous with current replication position.
+	if pos.TXID+1 != hdr.MinTXID || pos.PostApplyChecksum != hdr.PreApplyChecksum {
+		return ltx.NewPosMismatchError(pos)
+	}
+
+	// Write file to a temporary file.
+	filename := filepath.Join(c.path, name, ltx.FormatFilename(hdr.MinTXID, hdr.MaxTXID))
+	tempFilename := filename + ".tmp"
+	if err := os.MkdirAll(filepath.Dir(tempFilename), 0777); err != nil {
+		return err
+	}
+	f, err := os.Create(tempFilename)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	// Copy & sync the file.
+	if _, err := io.Copy(f, r); err != nil {
+		return err
+	} else if err := f.Sync(); err != nil {
+		return err
+	}
+
+	// Verify the contents of the file.
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return err
+	} else if err := ltx.NewDecoder(f).Verify(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	// Atomically rename the file.
+	if err := os.Rename(tempFilename, filename); err != nil {
+		return err
+	} else if err := internal.Sync(filepath.Dir(filename)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// FetchSnapshot requests a full snapshot of the database as it exists on
+// the backup service. This should be used if the LiteFS node has become
+// out of sync with the backup service.
+func (c *FileBackupClient) FetchSnapshot(ctx context.Context, name string) (_ io.ReadCloser, retErr error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	dir := filepath.Join(c.path, name)
+	ents, err := os.ReadDir(dir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	// Collect the filenames of all LTX files.
+	var filenames []string
+	for _, ent := range ents {
+		if ent.IsDir() || filepath.Ext(ent.Name()) != ".ltx" {
+			continue
+		}
+		filenames = append(filenames, ent.Name())
+	}
+
+	// Return an error if we have no LTX data for the database.
+	if len(filenames) == 0 {
+		return nil, os.ErrNotExist
+	}
+	sort.Strings(filenames)
+
+	// Build sorted reader list for compactor.
+	var rdrs []io.Reader
+	defer func() {
+		if retErr != nil {
+			for _, r := range rdrs {
+				_ = r.(io.Closer).Close()
+			}
+		}
+	}()
+	for _, filename := range filenames {
+		f, err := os.Open(filepath.Join(dir, filename))
+		if err != nil {
+			return nil, err
+		}
+		rdrs = append(rdrs, f)
+	}
+
+	// Send compaction through a pipe so we can convert it to an io.Reader.
+	pr, pw := io.Pipe()
+	go func() {
+		compactor := ltx.NewCompactor(pw, rdrs)
+		_ = pw.CloseWithError(compactor.Compact(ctx))
+	}()
+	return pr, nil
+}

--- a/backup_client_test.go
+++ b/backup_client_test.go
@@ -1,0 +1,219 @@
+package litefs_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/superfly/litefs"
+	"github.com/superfly/ltx"
+)
+
+func TestFileBackupClient_URL(t *testing.T) {
+	c := litefs.NewFileBackupClient("/path/to/data")
+	if got, want := c.URL(), `file:///path/to/data`; got != want {
+		t.Fatalf("URL=%s, want %s", got, want)
+	}
+}
+
+func TestFileBackupClient_WriteTx(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		c := newOpenFileBackupClient(t)
+
+		// Write several transaction files to the client.
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 1000},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 3, MaxTXID: 4, PreApplyChecksum: ltx.ChecksumFlag | 2000},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{3}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 3000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write to a different database.
+		if err := c.WriteTx(context.Background(), "db2", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{5}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 5000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		// Read snapshot from backup service.
+		var other ltx.FileSpec
+		if rc, err := c.FetchSnapshot(context.Background(), "db"); err != nil {
+			t.Fatal(err)
+		} else if _, err := other.ReadFrom(rc); err != nil {
+			t.Fatal(err)
+		} else if err := rc.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify contents of the snapshot.
+		if got, want := &other, (&ltx.FileSpec{
+			Header: ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 1, MaxTXID: 4},
+			Pages: []ltx.PageSpec{
+				{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{3}, 512)},
+				{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)},
+			},
+			Trailer: ltx.Trailer{
+				PostApplyChecksum: ltx.ChecksumFlag | 3000,
+				FileChecksum:      0xc8d8c55bde12fe8d,
+			},
+		}); !reflect.DeepEqual(got, want) {
+			t.Fatalf("spec mismatch:\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+
+	t.Run("ErrPosMismatch/TXID", func(t *testing.T) {
+		c := newOpenFileBackupClient(t)
+
+		// Write the initial transaction.
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write a transaction that doesn't line up with the TXID.
+		var pmErr *ltx.PosMismatchError
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 3, MaxTXID: 3, PreApplyChecksum: ltx.ChecksumFlag | 1000},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
+		})); !errors.As(err, &pmErr) {
+			t.Fatalf("unexpected error: %s", err)
+		} else if got, want := pmErr.Pos, (ltx.Pos{TXID: 1, PostApplyChecksum: 0x80000000000003e8}); !reflect.DeepEqual(got, want) {
+			t.Fatalf("pos=%s, want %s", got, want)
+		}
+	})
+
+	t.Run("ErrPosMismatch/PostApplyChecksum", func(t *testing.T) {
+		c := newOpenFileBackupClient(t)
+
+		// Write the initial transaction.
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write a transaction that doesn't line up with the TXID.
+		var pmErr *ltx.PosMismatchError
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 2000},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
+		})); !errors.As(err, &pmErr) {
+			t.Fatalf("unexpected error: %s", err)
+		} else if got, want := pmErr.Pos, (ltx.Pos{TXID: 1, PostApplyChecksum: 0x80000000000003e8}); !reflect.DeepEqual(got, want) {
+			t.Fatalf("pos=%s, want %s", got, want)
+		}
+	})
+
+	t.Run("ErrPosMismatch/FirstTx", func(t *testing.T) {
+		c := newOpenFileBackupClient(t)
+
+		var pmErr *ltx.PosMismatchError
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 2000},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+		})); !errors.As(err, &pmErr) {
+			t.Fatalf("unexpected error: %s", err)
+		} else if got, want := pmErr.Pos, (ltx.Pos{}); !reflect.DeepEqual(got, want) {
+			t.Fatalf("pos=%s, want %s", got, want)
+		}
+	})
+}
+
+func TestFileBackupClient_PosMap(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		c := newOpenFileBackupClient(t)
+
+		if err := c.WriteTx(context.Background(), "db1", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := c.WriteTx(context.Background(), "db1", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 1000},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write to a different database.
+		if err := c.WriteTx(context.Background(), "db2", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{5}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 5000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		// Read snapshot from backup service.
+		if m, err := c.PosMap(context.Background()); err != nil {
+			t.Fatal(err)
+		} else if got, want := m, map[string]ltx.Pos{
+			"db1": {TXID: 0x2, PostApplyChecksum: 0x80000000000007d0},
+			"db2": {TXID: 0x1, PostApplyChecksum: 0x8000000000001388},
+		}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("map=%#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("NoDatabases", func(t *testing.T) {
+		c := newOpenFileBackupClient(t)
+		if m, err := c.PosMap(context.Background()); err != nil {
+			t.Fatal(err)
+		} else if got, want := m, map[string]ltx.Pos{}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("map=%#v, want %#v", got, want)
+		}
+	})
+}
+
+func newOpenFileBackupClient(tb testing.TB) *litefs.FileBackupClient {
+	tb.Helper()
+	c := litefs.NewFileBackupClient(tb.TempDir())
+	if err := c.Open(); err != nil {
+		tb.Fatal(err)
+	}
+	return c
+}
+
+// ltxFileSpecReader returns a spec as an io.Reader of its serialized bytes.
+func ltxFileSpecReader(tb testing.TB, spec *ltx.FileSpec) io.Reader {
+	tb.Helper()
+	var buf bytes.Buffer
+	if _, err := spec.WriteTo(&buf); err != nil {
+		tb.Fatal(err)
+	}
+	return bytes.NewReader(buf.Bytes())
+}

--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	HTTP    HTTPConfig    `yaml:"http"`
 	Proxy   ProxyConfig   `yaml:"proxy"`
 	Lease   LeaseConfig   `yaml:"lease"`
+	Backup  BackupConfig  `yaml:"backup"`
 	Tracing TracingConfig `yaml:"tracing"`
 }
 
@@ -49,6 +50,8 @@ func NewConfig() Config {
 	config.Lease.Candidate = true
 	config.Lease.ReconnectDelay = litefs.DefaultReconnectDelay
 	config.Lease.DemoteDelay = litefs.DefaultDemoteDelay
+
+	config.Backup.Delay = litefs.DefaultBackupDelay
 
 	config.Tracing.MaxSize = DefaultTracingMaxSize
 	config.Tracing.MaxCount = DefaultTracingMaxCount
@@ -145,6 +148,15 @@ type LeaseConfig struct {
 		TTL       time.Duration `yaml:"ttl"`
 		LockDelay time.Duration `yaml:"lock-delay"`
 	} `yaml:"consul"`
+}
+
+// BackupConfig represents a config for backup services.
+type BackupConfig struct {
+	Type    string        `yaml:"type"`
+	Path    string        `yaml:"path"`    // "file" type only
+	URL     string        `yaml:"url"`     // "liteserver" type only
+	Cluster string        `yaml:"cluster"` // "liteserver" type only
+	Delay   time.Duration `yaml:"-"`
 }
 
 // Tracing configuration defaults.

--- a/http/client.go
+++ b/http/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/superfly/litefs"
 	"github.com/superfly/litefs/internal/chunk"
+	"github.com/superfly/ltx"
 	"golang.org/x/net/http2"
 )
 
@@ -353,7 +354,7 @@ func (c *Client) Commit(ctx context.Context, primaryURL string, nodeID uint64, n
 }
 
 // Stream returns a snapshot and continuous stream of WAL updates.
-func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
+func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos) (io.ReadCloser, error) {
 	u, err := url.Parse(primaryURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid client URL: %w", err)

--- a/http/http.go
+++ b/http/http.go
@@ -9,10 +9,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/superfly/litefs"
+	"github.com/superfly/ltx"
 )
 
-func ReadPosMapFrom(r io.Reader) (map[string]litefs.Pos, error) {
+func ReadPosMapFrom(r io.Reader) (map[string]ltx.Pos, error) {
 	// Read entry count.
 	var n uint32
 	if err := binary.Read(r, binary.BigEndian, &n); err != nil {
@@ -20,7 +20,7 @@ func ReadPosMapFrom(r io.Reader) (map[string]litefs.Pos, error) {
 	}
 
 	// Read entries and insert into map.
-	m := make(map[string]litefs.Pos, n)
+	m := make(map[string]ltx.Pos, n)
 	for i := uint32(0); i < n; i++ {
 		var nameN uint32
 		if err := binary.Read(r, binary.BigEndian, &nameN); err != nil {
@@ -31,7 +31,7 @@ func ReadPosMapFrom(r io.Reader) (map[string]litefs.Pos, error) {
 			return nil, err
 		}
 
-		var pos litefs.Pos
+		var pos ltx.Pos
 		if err := binary.Read(r, binary.BigEndian, &pos.TXID); err != nil {
 			return nil, err
 		} else if err := binary.Read(r, binary.BigEndian, &pos.PostApplyChecksum); err != nil {
@@ -43,7 +43,7 @@ func ReadPosMapFrom(r io.Reader) (map[string]litefs.Pos, error) {
 	return m, nil
 }
 
-func WritePosMapTo(w io.Writer, m map[string]litefs.Pos) error {
+func WritePosMapTo(w io.Writer, m map[string]ltx.Pos) error {
 	// Sort keys for consistent output.
 	names := make([]string, 0, len(m))
 	for name := range m {

--- a/http/proxy_server.go
+++ b/http/proxy_server.go
@@ -190,7 +190,7 @@ func (s *ProxyServer) serveRead(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), s.PollTXIDTimeout)
 	defer cancel()
 
-	var pos litefs.Pos
+	var pos ltx.Pos
 LOOP:
 	for {
 		if pos = db.Pos(); pos.TXID >= txid {

--- a/litefs_test.go
+++ b/litefs_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/superfly/litefs"
+	"github.com/superfly/ltx"
 )
 
 func TestFileType_IsValid(t *testing.T) {
@@ -38,21 +39,21 @@ func TestFileType_IsValid(t *testing.T) {
 }
 
 func TestPos_IsZero(t *testing.T) {
-	if !(litefs.Pos{}).IsZero() {
+	if !(ltx.Pos{}).IsZero() {
 		t.Fatal("expected true")
 	}
-	if (litefs.Pos{TXID: 100}).IsZero() {
+	if (ltx.Pos{TXID: 100}).IsZero() {
 		t.Fatal("expected false")
-	} else if (litefs.Pos{PostApplyChecksum: 100}).IsZero() {
+	} else if (ltx.Pos{PostApplyChecksum: 100}).IsZero() {
 		t.Fatal("expected false")
 	}
 }
 
 func TestPos_MarshalJSON(t *testing.T) {
 	type T struct {
-		Pos litefs.Pos
+		Pos ltx.Pos
 	}
-	if data, err := json.Marshal(T{Pos: litefs.Pos{TXID: 1234, PostApplyChecksum: 100}}); err != nil {
+	if data, err := json.Marshal(T{Pos: ltx.Pos{TXID: 1234, PostApplyChecksum: 100}}); err != nil {
 		t.Fatal(err)
 	} else if got, want := string(data), `{"Pos":{"txid":"00000000000004d2","postApplyChecksum":"0000000000000064"}}`; got != want {
 		t.Fatalf("Marshal=%s, want %s", got, want)
@@ -61,13 +62,13 @@ func TestPos_MarshalJSON(t *testing.T) {
 
 func TestPos_UnmarshalJSON(t *testing.T) {
 	var v struct {
-		Pos litefs.Pos
+		Pos ltx.Pos
 	}
 
 	data := []byte(`{"Pos":{"txid":"00000000000004d2","postApplyChecksum":"0000000000000064"}}`)
 	if err := json.Unmarshal(data, &v); err != nil {
 		t.Fatal(err)
-	} else if got, want := v.Pos, (litefs.Pos{TXID: 1234, PostApplyChecksum: 100}); got != want {
+	} else if got, want := v.Pos, (ltx.Pos{TXID: 1234, PostApplyChecksum: 100}); got != want {
 		t.Fatalf("Unmarshal=%s, want %s", got, want)
 	}
 }

--- a/liteserver/backup_client.go
+++ b/liteserver/backup_client.go
@@ -1,0 +1,193 @@
+package liteserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/superfly/litefs"
+	"github.com/superfly/ltx"
+)
+
+var _ litefs.BackupClient = (*BackupClient)(nil)
+
+// BackupClient implements a backup client for a remote Liteserver.
+type BackupClient struct {
+	baseURL url.URL // remote liteserver URL
+	cluster string  // name of cluster
+
+	// Authentication fields passed in via the "Authorization" HTTP header.
+	AuthScheme string
+	AuthToken  string
+
+	HTTPClient *http.Client
+}
+
+// NewBackupClient returns a new instance of BackupClient.
+func NewBackupClient(u url.URL, cluster string) *BackupClient {
+	return &BackupClient{
+		baseURL: url.URL{
+			Scheme: u.Scheme,
+			Host:   u.Host,
+		},
+		cluster: cluster,
+
+		HTTPClient: &http.Client{},
+	}
+}
+
+// Open validates the URL the client was initialized with.
+func (c *BackupClient) Open() (err error) {
+	if c.baseURL.Scheme != "http" && c.baseURL.Scheme != "https" {
+		return fmt.Errorf("invalid liteserver URL scheme: %q", c.baseURL.Scheme)
+	} else if c.baseURL.Host == "" {
+		return fmt.Errorf("liteserver URL host required: %q", c.baseURL.String())
+	}
+
+	if c.cluster == "" {
+		return fmt.Errorf("cluster name required")
+	}
+
+	return nil
+}
+
+// URL of the backup service.
+func (c *BackupClient) URL() string {
+	return c.baseURL.String()
+}
+
+// Cluster returns the name of the cluster that the client was initialized with.
+func (c *BackupClient) Cluster() string {
+	return c.cluster
+}
+
+// PosMap returns the replication position for all databases on the backup service.
+func (c *BackupClient) PosMap(ctx context.Context) (map[string]ltx.Pos, error) {
+	req, err := c.newRequest(http.MethodGet, "/pos", url.Values{"cluster": {c.cluster}}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	m := make(map[string]ltx.Pos)
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// WriteTx writes an LTX file to the backup service. The file must be
+// contiguous with the latest LTX file on the backup service or else it
+// will return an ltx.PosMismatchError.
+func (c *BackupClient) WriteTx(ctx context.Context, name string, r io.Reader) error {
+	req, err := c.newRequest(http.MethodPost, "/db/tx", url.Values{
+		"cluster": {c.cluster},
+		"db":      {name},
+	}, r)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return err
+	} else if err := resp.Body.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// FetchSnapshot requests a full snapshot of the database as it exists on
+// the backup service. This should be used if the LiteFS node has become
+// out of sync with the backup service.
+func (c *BackupClient) FetchSnapshot(ctx context.Context, name string) (io.ReadCloser, error) {
+	req, err := c.newRequest(http.MethodGet, "/db/snapshot", url.Values{
+		"cluster": {c.cluster},
+		"db":      {name},
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}
+
+// newRequest returns a new HTTP request with the given context & auth parameters.
+func (c *BackupClient) newRequest(method, path string, q url.Values, body io.Reader) (*http.Request, error) {
+	u := c.baseURL
+	u.Path = path
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(method, u.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the auth header if scheme & token are provided. Otherwise send without auth.
+	if c.AuthScheme != "" && c.AuthToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("%s %s", c.AuthScheme, c.AuthToken))
+	}
+	return req, nil
+}
+
+// doRequest executes the request and returns an error if the response is not a 2XX.
+func (c *BackupClient) doRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
+	resp, err := c.HTTPClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	// If this is not a 2XX code then read the body as an error message.
+	if !isSuccessfulStatusCode(resp.StatusCode) {
+		return nil, readResponseError(resp)
+	}
+
+	return resp, nil
+}
+
+// readResponseError reads the response body as an error message & closes the body.
+func readResponseError(resp *http.Response) error {
+	defer func() { _ = resp.Body.Close() }()
+
+	// Read up to 64KB of data from the body for the error message.
+	buf, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return err
+	}
+
+	// Attempt to decode as a JSON error.
+	var e errorResponse
+	if err := json.Unmarshal(buf, &e); err != nil {
+		return fmt.Errorf("backup client error (%d): %s", resp.StatusCode, string(buf))
+	}
+
+	// Match specific types of errors.
+	switch e.Code {
+	case "EPOSMISMATCH":
+		return ltx.NewPosMismatchError(e.Pos)
+	default:
+		return fmt.Errorf("backup client error (%d): %s", resp.StatusCode, e.Error)
+	}
+}
+
+type errorResponse struct {
+	Code  string  `json:"code"`
+	Error string  `json:"error"`
+	Pos   ltx.Pos `json:"pos"`
+}
+
+func isSuccessfulStatusCode(code int) bool {
+	return code >= 200 && code < 300
+}

--- a/liteserver/backup_client_test.go
+++ b/liteserver/backup_client_test.go
@@ -1,0 +1,254 @@
+package liteserver_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/superfly/litefs/liteserver"
+	"github.com/superfly/ltx"
+)
+
+var integration = flag.Bool("integration", false, "run integration tests")
+
+func TestFileBackupClient_URL(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		c := liteserver.NewBackupClient(url.URL{Scheme: "http", Host: "localhost:1234"}, "mycluster")
+		if got, want := c.URL(), `http://localhost:1234`; got != want {
+			t.Fatalf("URL=%s, want %s", got, want)
+		}
+	})
+	t.Run("Strip", func(t *testing.T) {
+		c := liteserver.NewBackupClient(url.URL{
+			Scheme: "http",
+			Host:   "localhost:1234",
+			Path:   "/foo/bar",
+		}, "mycluster")
+		if got, want := c.URL(), `http://localhost:1234`; got != want {
+			t.Fatalf("URL=%s, want %s", got, want)
+		}
+	})
+}
+
+func TestFileBackupClient_Cluster(t *testing.T) {
+	c := liteserver.NewBackupClient(url.URL{Scheme: "http", Host: "localhost:1234"}, "mycluster")
+	if got, want := c.Cluster(), `mycluster`; got != want {
+		t.Fatalf("cluster=%s, want %s", got, want)
+	}
+}
+
+func TestFileBackupClient_WriteTx(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		c := newOpenBackupClient(t)
+
+		// Write several transaction files to the client.
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 1000},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 3, MaxTXID: 4, PreApplyChecksum: ltx.ChecksumFlag | 2000},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{3}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 3000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write to a different database.
+		if err := c.WriteTx(context.Background(), "db2", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{5}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 5000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		// Read snapshot from backup service.
+		var other ltx.FileSpec
+		if rc, err := c.FetchSnapshot(context.Background(), "db"); err != nil {
+			t.Fatal(err)
+		} else if _, err := other.ReadFrom(rc); err != nil {
+			t.Fatal(err)
+		} else if err := rc.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify contents of the snapshot.
+		if got, want := &other, (&ltx.FileSpec{
+			Header: ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 1, MaxTXID: 4},
+			Pages: []ltx.PageSpec{
+				{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{3}, 512)},
+				{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)},
+			},
+			Trailer: ltx.Trailer{
+				PostApplyChecksum: ltx.ChecksumFlag | 3000,
+				FileChecksum:      0xc8d8c55bde12fe8d,
+			},
+		}); !reflect.DeepEqual(got, want) {
+			t.Fatalf("spec mismatch:\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+
+	t.Run("ErrPosMismatch/TXID", func(t *testing.T) {
+		c := newOpenBackupClient(t)
+
+		// Write the initial transaction.
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write a transaction that doesn't line up with the TXID.
+		var pmErr *ltx.PosMismatchError
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 3, MaxTXID: 3, PreApplyChecksum: ltx.ChecksumFlag | 1000},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
+		})); !errors.As(err, &pmErr) {
+			t.Fatalf("unexpected error: %s", err)
+		} else if got, want := pmErr.Pos, (ltx.Pos{TXID: 1, PostApplyChecksum: 0x80000000000003e8}); !reflect.DeepEqual(got, want) {
+			t.Fatalf("pos=%s, want %s", got, want)
+		}
+	})
+
+	t.Run("ErrPosMismatch/PostApplyChecksum", func(t *testing.T) {
+		c := newOpenBackupClient(t)
+
+		// Write the initial transaction.
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write a transaction that doesn't line up with the TXID.
+		var pmErr *ltx.PosMismatchError
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 2000},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
+		})); !errors.As(err, &pmErr) {
+			t.Fatalf("unexpected error: %s", err)
+		} else if got, want := pmErr.Pos, (ltx.Pos{TXID: 1, PostApplyChecksum: 0x80000000000003e8}); !reflect.DeepEqual(got, want) {
+			t.Fatalf("pos=%s, want %s", got, want)
+		}
+	})
+
+	t.Run("ErrPosMismatch/FirstTx", func(t *testing.T) {
+		c := newOpenBackupClient(t)
+
+		var pmErr *ltx.PosMismatchError
+		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 2000},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+		})); !errors.As(err, &pmErr) {
+			t.Fatalf("unexpected error: %s", err)
+		} else if got, want := pmErr.Pos, (ltx.Pos{}); !reflect.DeepEqual(got, want) {
+			t.Fatalf("pos=%s, want %s", got, want)
+		}
+	})
+}
+
+func TestFileBackupClient_PosMap(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		c := newOpenBackupClient(t)
+
+		if err := c.WriteTx(context.Background(), "db1", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := c.WriteTx(context.Background(), "db1", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 1000},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write to a different database.
+		if err := c.WriteTx(context.Background(), "db2", ltxFileSpecReader(t, &ltx.FileSpec{
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
+			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{5}, 512)}},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 5000},
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		// Read snapshot from backup service.
+		if m, err := c.PosMap(context.Background()); err != nil {
+			t.Fatal(err)
+		} else if got, want := m, map[string]ltx.Pos{
+			"db1": {TXID: 0x2, PostApplyChecksum: 0x80000000000007d0},
+			"db2": {TXID: 0x1, PostApplyChecksum: 0x8000000000001388},
+		}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("map=%#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("NoDatabases", func(t *testing.T) {
+		c := newOpenBackupClient(t)
+		if m, err := c.PosMap(context.Background()); err != nil {
+			t.Fatal(err)
+		} else if got, want := m, map[string]ltx.Pos{}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("map=%#v, want %#v", got, want)
+		}
+	})
+}
+
+func newOpenBackupClient(tb testing.TB) *liteserver.BackupClient {
+	tb.Helper()
+
+	if !*integration {
+		tb.Skip("integration tests not enabled, skipping")
+	}
+
+	c := liteserver.NewBackupClient(
+		url.URL{Scheme: "http", Host: "localhost:21212"},
+		fmt.Sprintf("test%d", rand.Intn(1000000)),
+	)
+	if err := c.Open(); err != nil {
+		tb.Fatal(err)
+	}
+
+	tb.Logf("initializing client for test cluster: %s", c.Cluster())
+	return c
+}
+
+// ltxFileSpecReader returns a spec as an io.Reader of its serialized bytes.
+func ltxFileSpecReader(tb testing.TB, spec *ltx.FileSpec) io.Reader {
+	tb.Helper()
+	var buf bytes.Buffer
+	if _, err := spec.WriteTo(&buf); err != nil {
+		tb.Fatal(err)
+	}
+	return bytes.NewReader(buf.Bytes())
+}

--- a/mock/client.go
+++ b/mock/client.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/superfly/litefs"
+	"github.com/superfly/ltx"
 )
 
 var _ litefs.Client = (*Client)(nil)
@@ -13,7 +14,7 @@ type Client struct {
 	AcquireHaltLockFunc func(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) (*litefs.HaltLock, error)
 	ReleaseHaltLockFunc func(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) error
 	CommitFunc          func(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64, r io.Reader) error
-	StreamFunc          func(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]litefs.Pos) (io.ReadCloser, error)
+	StreamFunc          func(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos) (io.ReadCloser, error)
 }
 
 func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) (*litefs.HaltLock, error) {
@@ -28,6 +29,6 @@ func (c *Client) Commit(ctx context.Context, primaryURL string, nodeID uint64, n
 	return c.CommitFunc(ctx, primaryURL, nodeID, name, lockID, r)
 }
 
-func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
+func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos) (io.ReadCloser, error) {
 	return c.StreamFunc(ctx, primaryURL, nodeID, posMap)
 }

--- a/store_test.go
+++ b/store_test.go
@@ -32,7 +32,7 @@ func TestStore_CreateDB(t *testing.T) {
 	if got, want := db.Name(), "test1.db"; got != want {
 		t.Fatalf("Name=%s, want %s", got, want)
 	}
-	if got, want := db.Pos(), (litefs.Pos{}); !reflect.DeepEqual(got, want) {
+	if got, want := db.Pos(), (ltx.Pos{}); !reflect.DeepEqual(got, want) {
 		t.Fatalf("Pos=%#v, want %#v", got, want)
 	}
 	if got, want := db.TXID(), uint64(0); !reflect.DeepEqual(got, want) {
@@ -71,7 +71,7 @@ func TestStore_Open(t *testing.T) {
 		if got, want := db.Name(), "test.db"; got != want {
 			t.Fatalf("name=%v, want %v", got, want)
 		}
-		if got, want := db.Pos(), (litefs.Pos{}); got != want {
+		if got, want := db.Pos(), (ltx.Pos{}); got != want {
 			t.Fatalf("pos=%v, want %v", got, want)
 		}
 
@@ -100,7 +100,7 @@ func TestStore_Open(t *testing.T) {
 		if got, want := db.Name(), "test.db"; got != want {
 			t.Fatalf("name=%v, want %v", got, want)
 		}
-		if got, want := db.Pos(), (litefs.Pos{}); got != want {
+		if got, want := db.Pos(), (ltx.Pos{}); got != want {
 			t.Fatalf("pos=%v, want %v", got, want)
 		}
 	})
@@ -118,7 +118,7 @@ func TestStore_Open(t *testing.T) {
 		if got, want := db.Name(), "test.db"; got != want {
 			t.Fatalf("name=%v, want %v", got, want)
 		}
-		if got, want := db.Pos(), (litefs.Pos{}); got != want {
+		if got, want := db.Pos(), (ltx.Pos{}); got != want {
 			t.Fatalf("pos=%v, want %v", got, want)
 		}
 	})
@@ -224,7 +224,7 @@ func TestStore_PrimaryCtx(t *testing.T) {
 		}
 
 		client := mock.Client{
-			StreamFunc: func(ctx context.Context, rawurl string, nodeID uint64, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
+			StreamFunc: func(ctx context.Context, rawurl string, nodeID uint64, posMap map[string]ltx.Pos) (io.ReadCloser, error) {
 				return io.NopCloser(&bytes.Buffer{}), nil
 			},
 		}
@@ -254,7 +254,7 @@ func TestStore_PrimaryCtx(t *testing.T) {
 	t.Run("InitialReplica", func(t *testing.T) {
 		leaser := litefs.NewStaticLeaser(false, "localhost", "http://localhost:20202")
 		client := mock.Client{
-			StreamFunc: func(ctx context.Context, rawurl string, nodeID uint64, posMap map[string]litefs.Pos) (io.ReadCloser, error) {
+			StreamFunc: func(ctx context.Context, rawurl string, nodeID uint64, posMap map[string]ltx.Pos) (io.ReadCloser, error) {
 				var buf bytes.Buffer
 				if err := litefs.WriteStreamFrame(&buf, &litefs.ReadyStreamFrame{}); err != nil {
 					return nil, err


### PR DESCRIPTION
This is an initial implementation of the streaming backup client. This functions similarly to Litestream in that it pushes up changes periodically (currently every second). One big difference is that since LiteFS uses LTX for storage, multiple changes to the same page over that period can be compacted into a single page transferred.

Related to #18.

## Implementations

There are currently two implementations of `BackupClient`:

- `"file"` - this pushes to a directory on the local file system & is mainly used for testing.
- `"liteserver"` - this pushes to Liteserver which handles leveled compaction, snapshotting, & pushing to S3.

## Liteserver

Originally, we were going to try to put S3 replication directly into LiteFS but it gets complicated since the primary is dynamic. We also have plans for allowing LiteFS to be run ephemerally and having a central service available to page data out as-needed. Because of those reasons, we moved the S3 replication into a separate service called Liteserver.

Liteserver is not currently open source. We decided to keep it closed initially as it is faster to iterate on in this early stage.
