### PR TITLE
Fix CI error on close

### DIFF
--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -1838,7 +1838,7 @@ func runMountCommand(tb testing.TB, cmd *main.MountCommand) *main.MountCommand {
 		tb.Fatal(err)
 	}
 	tb.Cleanup(func() {
-		if err := cmd.Close(); err != nil {
+		if err := cmd.Close(); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
 			log.Printf("cannot close mount command: %s", err)
 		}
 	})


### PR DESCRIPTION
This should help avoid a harmless timing issue on test shutdown. 