### PR TITLE
Use ltx.TXID

### DIFF
--- a/cmd/litefs-bench/main.go
+++ b/cmd/litefs-bench/main.go
@@ -113,7 +113,7 @@ func run(ctx context.Context) error {
 			case "query":
 				err = runQueryIter(ctx, db, rand)
 			default:
-				return fmt.Errorf("invalid bench mode: %q", mode)
+				return fmt.Errorf("invalid bench mode: %q", *mode)
 			}
 			if err != nil {
 				return fmt.Errorf("iter %d: %w", i, err)

--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/superfly/litefs"
 	main "github.com/superfly/litefs/cmd/litefs"
 	"github.com/superfly/litefs/internal/testingutil"
+	"github.com/superfly/ltx"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 )
@@ -113,7 +114,7 @@ func TestSingleNode_CorruptLTX(t *testing.T) {
 	}
 
 	// Determine TXID based on journal mode.
-	txID := uint64(2)
+	txID := ltx.TXID(2)
 	if testingutil.IsWALMode() {
 		txID++
 	}

--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/superfly/litefs"
 	"github.com/superfly/litefs/fuse"
 	"github.com/superfly/litefs/internal/testingutil"
+	"github.com/superfly/ltx"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 )
@@ -217,7 +218,7 @@ func TestFileSystem_NoWrite(t *testing.T) {
 	dsn := filepath.Join(fs.Path(), "db")
 	db := testingutil.OpenSQLDB(t, dsn)
 
-	var txID uint64
+	var txID ltx.TXID
 	if db := fs.Store().DB("db"); db != nil {
 		txID = db.TXID()
 	}
@@ -290,7 +291,7 @@ func TestFileSystem_MultipleJournalSegments(t *testing.T) {
 	}
 
 	// Ensure the transaction ID has not incremented.
-	if got, want := fs.Store().DB("db").TXID(), uint64(txID+2); got != want {
+	if got, want := fs.Store().DB("db").TXID(), ltx.TXID(txID+2); got != want {
 		t.Fatalf("txid=%d, want %d", got, want)
 	}
 
@@ -746,7 +747,7 @@ func TestFileSystem_OutOfSyncWAL(t *testing.T) {
 	}
 
 	// Verify transaction count.
-	if got, want := fs.Store().DB("db").TXID(), uint64(5); got != want {
+	if got, want := fs.Store().DB("db").TXID(), ltx.TXID(5); got != want {
 		t.Fatalf("txid=%d, want %d", got, want)
 	}
 
@@ -797,7 +798,7 @@ func TestFileSystem_OutOfSyncWAL(t *testing.T) {
 	}
 
 	// Verify transaction count.
-	if got, want := fs.Store().DB("db").TXID(), uint64(4); got != want {
+	if got, want := fs.Store().DB("db").TXID(), ltx.TXID(4); got != want {
 		t.Fatalf("txid=%d, want %d", got, want)
 	}
 }

--- a/fuse/pos_node.go
+++ b/fuse/pos_node.go
@@ -49,7 +49,7 @@ func (n *PosNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.Op
 func (n *PosNode) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
 	pos := n.db.Pos()
 
-	data := fmt.Sprintf("%016x/%016x\n", pos.TXID, pos.PostApplyChecksum)
+	data := fmt.Sprintf("%s/%016x\n", pos.TXID.String(), pos.PostApplyChecksum)
 	if req.Offset >= int64(len(data)) {
 		return io.EOF
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.16-0.20220918133448-90900be5db1a
 	github.com/prometheus/client_golang v1.13.0
 	github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b
-	github.com/superfly/ltx v0.3.1
+	github.com/superfly/ltx v0.3.2
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/sys v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b h1:+WuhtZFB8fNdPeaMUtuB/U8aknXBXdDW/mBm/HTYJNg=
 github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b/go.mod h1:h+GUx1V2s0C5nY73ZN82760eWEJrpMaiDweF31VmJKk=
-github.com/superfly/ltx v0.3.1 h1:4cfmSFIndcp+AOyowdnk5oIPBiily3e+kdyRYyzXZVE=
-github.com/superfly/ltx v0.3.1/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
+github.com/superfly/ltx v0.3.2 h1:anyAzJvIO4vwGNWtlVkS15UW/gZhVFqmatQAtzVumFk=
+github.com/superfly/ltx v0.3.2/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/store.go
+++ b/store.go
@@ -1090,7 +1090,7 @@ func (s *Store) processLTXStreamFrame(ctx context.Context, frame *LTXStreamFrame
 	}
 	src = io.MultiReader(bytes.NewReader(data), src)
 
-	TraceLog.Printf("%s [ProcessLTXStreamFrame.Begin(%s)]: txid=%s-%s, preApplyChecksum=%016x", s.LogPrefix(), db.Name(), ltx.FormatTXID(hdr.MinTXID), ltx.FormatTXID(hdr.MaxTXID), hdr.PreApplyChecksum)
+	TraceLog.Printf("%s [ProcessLTXStreamFrame.Begin(%s)]: txid=%s-%s, preApplyChecksum=%016x", s.LogPrefix(), db.Name(), hdr.MinTXID.String(), hdr.MaxTXID.String(), hdr.PreApplyChecksum)
 	defer func() {
 		TraceLog.Printf("%s [ProcessLTXStreamFrame.End(%s)]: %s", db.store.LogPrefix(), db.name, errorKeyValue(err))
 	}()
@@ -1214,7 +1214,7 @@ func (v *StoreVar) String() string {
 
 		dbJSON := &dbVarJSON{
 			Name:     db.Name(),
-			TXID:     ltx.FormatTXID(pos.TXID),
+			TXID:     pos.TXID.String(),
 			Checksum: fmt.Sprintf("%016x", pos.PostApplyChecksum),
 		}
 

--- a/store_test.go
+++ b/store_test.go
@@ -35,7 +35,7 @@ func TestStore_CreateDB(t *testing.T) {
 	if got, want := db.Pos(), (ltx.Pos{}); !reflect.DeepEqual(got, want) {
 		t.Fatalf("Pos=%#v, want %#v", got, want)
 	}
-	if got, want := db.TXID(), uint64(0); !reflect.DeepEqual(got, want) {
+	if got, want := db.TXID(), ltx.TXID(0); !reflect.DeepEqual(got, want) {
 		t.Fatalf("TXID=%#v, want %#v", got, want)
 	}
 	if got, want := db.Path(), filepath.Join(store.Path(), "dbs", "test1.db"); got != want {


### PR DESCRIPTION
This upgrades to LTX v0.3.2 and uses the new `ltx.TXID` to represent transaction IDs instead of `uint64`.