### PR TITLE
Initiate backup from snapshot

### DIFF
--- a/cmd/litefs/mount_darwin.go
+++ b/cmd/litefs/mount_darwin.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/superfly/litefs"
 	"github.com/superfly/litefs/http"
 )
 
 // MountCommand represents a command to mount the file system.
 type MountCommand struct {
 	Config Config
+	Store  *litefs.Store
 
 	ProxyServer *http.ProxyServer
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.16-0.20220918133448-90900be5db1a
 	github.com/prometheus/client_golang v1.13.0
 	github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b
-	github.com/superfly/ltx v0.3.2
+	github.com/superfly/ltx v0.3.3-0.20230516181327-9fabe139c9c8
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/sys v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b h1:+WuhtZFB8fNdPeaMUtuB/U8aknXBXdDW/mBm/HTYJNg=
 github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b/go.mod h1:h+GUx1V2s0C5nY73ZN82760eWEJrpMaiDweF31VmJKk=
-github.com/superfly/ltx v0.3.2 h1:anyAzJvIO4vwGNWtlVkS15UW/gZhVFqmatQAtzVumFk=
-github.com/superfly/ltx v0.3.2/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
+github.com/superfly/ltx v0.3.3-0.20230516181327-9fabe139c9c8 h1:h7HBghgAmHDh4GnxZkEdb4hvDHsWBoD2oyDgQRAi0aA=
+github.com/superfly/ltx v0.3.3-0.20230516181327-9fabe139c9c8/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
This pull request fixes the backup client so that it will start with a full snapshot if the remote backup server does not have a replication position for the database. This is needed when the initial LTX file has been removed because of retention enforcement.