### PR TITLE
Use HWM during retention enforcement

### DIFF
--- a/backup_client_test.go
+++ b/backup_client_test.go
@@ -24,15 +24,17 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 		c := newOpenFileBackupClient(t)
 
 		// Write several transaction files to the client.
-		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+		if hwm, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
 		})); err != nil {
 			t.Fatal(err)
+		} else if got, want := hwm, ltx.TXID(1); got != want {
+			t.Fatalf("hwm=%s, want %s", got, want)
 		}
 
-		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+		if _, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 1000},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
@@ -40,7 +42,7 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+		if _, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 3, MaxTXID: 4, PreApplyChecksum: ltx.ChecksumFlag | 2000},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{3}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 3000},
@@ -49,7 +51,7 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 		}
 
 		// Write to a different database.
-		if err := c.WriteTx(context.Background(), "db2", ltxFileSpecReader(t, &ltx.FileSpec{
+		if _, err := c.WriteTx(context.Background(), "db2", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{5}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 5000},
@@ -87,7 +89,7 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 		c := newOpenFileBackupClient(t)
 
 		// Write the initial transaction.
-		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+		if _, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
@@ -97,7 +99,7 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 
 		// Write a transaction that doesn't line up with the TXID.
 		var pmErr *ltx.PosMismatchError
-		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+		if _, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 3, MaxTXID: 3, PreApplyChecksum: ltx.ChecksumFlag | 1000},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
@@ -112,7 +114,7 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 		c := newOpenFileBackupClient(t)
 
 		// Write the initial transaction.
-		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+		if _, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
@@ -122,7 +124,7 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 
 		// Write a transaction that doesn't line up with the TXID.
 		var pmErr *ltx.PosMismatchError
-		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+		if _, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 2000},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
@@ -137,7 +139,7 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 		c := newOpenFileBackupClient(t)
 
 		var pmErr *ltx.PosMismatchError
-		if err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
+		if _, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 2000},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
@@ -153,7 +155,7 @@ func TestFileBackupClient_PosMap(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		c := newOpenFileBackupClient(t)
 
-		if err := c.WriteTx(context.Background(), "db1", ltxFileSpecReader(t, &ltx.FileSpec{
+		if _, err := c.WriteTx(context.Background(), "db1", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
@@ -161,7 +163,7 @@ func TestFileBackupClient_PosMap(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := c.WriteTx(context.Background(), "db1", ltxFileSpecReader(t, &ltx.FileSpec{
+		if _, err := c.WriteTx(context.Background(), "db1", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 1000},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
@@ -170,7 +172,7 @@ func TestFileBackupClient_PosMap(t *testing.T) {
 		}
 
 		// Write to a different database.
-		if err := c.WriteTx(context.Background(), "db2", ltxFileSpecReader(t, &ltx.FileSpec{
+		if _, err := c.WriteTx(context.Background(), "db2", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{5}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 5000},


### PR DESCRIPTION
This pull request returns the high-water mark (HWM) returned from Liteserver during the `BackupClient.WriteTx()` API call and sets it on the `DB`. During retention enforcement, this high-water mark will be used to retain LTX files which have not made it to long-term storage. This ensures that LiteFS can sync up with Liteserver even when there is a catastrophic crash of the Liteserver disk.

Propagation of HWM to replica nodes will be done in a separate PR.