### PR TITLE
Propagate high-water mark to replicas

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -127,3 +127,35 @@ func TestReadyStreamFrame_WriteTo(t *testing.T) {
 		}
 	})
 }
+
+func TestHWMStreamFrame_ReadFrom(t *testing.T) {
+	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
+		frame := &litefs.HWMStreamFrame{TXID: 1234, Name: "test.db"}
+		var buf bytes.Buffer
+		if _, err := frame.WriteTo(&buf); err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < buf.Len(); i++ {
+			var other litefs.HWMStreamFrame
+			if _, err := other.ReadFrom(bytes.NewReader(buf.Bytes()[:i])); err != io.ErrUnexpectedEOF {
+				t.Fatalf("expected error at %d bytes: %s", i, err)
+			}
+		}
+	})
+}
+
+func TestHWMStreamFrame_WriteTo(t *testing.T) {
+	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
+		frame := &litefs.HWMStreamFrame{TXID: 1234, Name: "test.db"}
+		var buf bytes.Buffer
+		if _, err := frame.WriteTo(&buf); err != nil {
+			t.Fatal(err)
+		}
+
+		for i := 0; i < buf.Len(); i++ {
+			if _, err := frame.WriteTo(&errWriter{afterN: i}); err == nil || err.Error() != `write error occurred` {
+				t.Fatalf("expected error at %d bytes: %s", i, err)
+			}
+		}
+	})
+}

--- a/store.go
+++ b/store.go
@@ -1049,6 +1049,10 @@ func (s *Store) monitorLeaseAsReplica(ctx context.Context, info *PrimaryInfo) (h
 			}
 		case *HandoffStreamFrame:
 			return frame.LeaseID, nil
+		case *HWMStreamFrame:
+			if db := s.DB(frame.Name); db != nil {
+				db.SetHWM(frame.TXID)
+			}
 		default:
 			return "", fmt.Errorf("invalid stream frame type: 0x%02x", frame.Type())
 		}


### PR DESCRIPTION
This pull request adds an `HWMStreamFrame` that allows the primary to propagate its local high-water mark for a database to all connected replicas. This will allow replicas to reclaim space from LTX files that have been persisted to long-term storage.

This is a naive implementation in that it only pushes out the HWM when a write transaction occurs. Every LTX stream frame will be followed by an HWM stream frame. There are edge cases that are not handled such as a large number of writes within a second followed by no writes. In those cases, the underlying LTX files will continue to persist on disk. However, those will be reclaimed once another write occurs and the HWM is propagated.