### PR TITLE
Restore from backup when out-of-sync

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	Proxy   ProxyConfig   `yaml:"proxy"`
 	Lease   LeaseConfig   `yaml:"lease"`
 	Backup  BackupConfig  `yaml:"backup"`
+	Log     LogConfig     `yaml:"log"`
 	Tracing TracingConfig `yaml:"tracing"`
 }
 
@@ -52,6 +53,8 @@ func NewConfig() Config {
 	config.Lease.DemoteDelay = litefs.DefaultDemoteDelay
 
 	config.Backup.Delay = litefs.DefaultBackupDelay
+
+	config.Log.Format = "text"
 
 	config.Tracing.MaxSize = DefaultTracingMaxSize
 	config.Tracing.MaxCount = DefaultTracingMaxCount
@@ -157,6 +160,12 @@ type BackupConfig struct {
 	URL     string        `yaml:"url"`     // "liteserver" type only
 	Cluster string        `yaml:"cluster"` // "liteserver" type only
 	Delay   time.Duration `yaml:"-"`
+}
+
+// LogConfig represents the configuration for logging.
+type LogConfig struct {
+	Format string `yaml:"format"` // "text", "json"
+	Debug  bool   `yaml:"debug"`  // include debug logging
 }
 
 // Tracing configuration defaults.

--- a/cmd/litefs/main_test.go
+++ b/cmd/litefs/main_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/superfly/litefs"
+	"golang.org/x/exp/slog"
 )
 
 //go:embed testdata
@@ -21,6 +22,7 @@ var (
 
 func init() {
 	log.SetFlags(0)
+	litefs.LogLevel.Set(slog.LevelDebug)
 }
 
 func TestMain(m *testing.M) {

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -337,6 +337,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=
+golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/litefs.go
+++ b/litefs.go
@@ -9,12 +9,21 @@ import (
 	"io"
 	"log"
 	"strconv"
+	"sync"
 	"unsafe"
+
+	"golang.org/x/exp/slog"
 )
 
 func init() {
 	assert(unsafe.Sizeof(walIndexHdr{}) == 48, "invalid walIndexHdr size")
 	assert(unsafe.Sizeof(walCkptInfo{}) == 40, "invalid walCkptInfo size")
+}
+
+// Global log level. Can be adjusted dynamically.
+var LogLevel struct {
+	sync.Mutex
+	slog.LevelVar
 }
 
 // NodeInfo represents basic info about a node.


### PR DESCRIPTION
This pull request handles divergence between the backup service and the LiteFS cluster. Because LiteFS does asynchronous replication, it's possible to have a primary node with unreplicated transactions that is disconnected the cluster and the rest of the cluster can diverge in a different transaction lineage.

Normally, this is handled by the new primary, however, there are instances where divergence can occur (e.g. primary loses role and later reacquires the primary status but transactions have been sent to the backup service). The backup service acts as a data authority so if LiteFS cannot determine a common transaction lineage, it must revert to the snapshot on the backup service.

## Understanding divergence

There are four situations where divergence can occur:

1. New primary is empty and local database does not exist but it does exist on the backup.

2. The TXID on the backup service is greater than local TXID. This occurs if the backup service received transactions before replicas.

3. The local TXID is the same as the backup TXID, however, the checksum is not the same. This occurs if the primary loses its primary status and has unreplicated transactions and the new primary diverges.

4. The local TXID is ahead of the backup TXID and not all the LTX files are available on the local disk. This should be prevented by #319 and #321.

Currently, the backup service does not have the ability to catch up LiteFS nodes in the case of number 2. That is a future optimization.

## Misc

This pull request also starts to introduce [slog](https://pkg.go.dev/golang.org/x/exp/slog) for logging. All logging will be switched out for `slog` in a separate PR.