### PR TITLE
Default slog to not print timestamp

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -164,8 +164,9 @@ type BackupConfig struct {
 
 // LogConfig represents the configuration for logging.
 type LogConfig struct {
-	Format string `yaml:"format"` // "text", "json"
-	Debug  bool   `yaml:"debug"`  // include debug logging
+	Format    string `yaml:"format"`    // "text", "json"
+	Timestamp bool   `yaml:"timestamp"` // include timestamp in log output
+	Debug     bool   `yaml:"debug"`     // include debug logging
 }
 
 // Tracing configuration defaults.

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -291,6 +291,10 @@ func (c *MountCommand) initLogger(ctx context.Context) error {
 
 	opts := slog.HandlerOptions{Level: &litefs.LogLevel}
 
+	if !c.Config.Log.Timestamp {
+		opts.ReplaceAttr = removeTime
+	}
+
 	var handler slog.Handler
 	switch format := c.Config.Log.Format; format {
 	case "text":
@@ -553,3 +557,11 @@ func (c *MountCommand) promote(ctx context.Context) (err error) {
 }
 
 var expvarOnce sync.Once
+
+// removeTime removes the "time" field from slog.
+func removeTime(groups []string, a slog.Attr) slog.Attr {
+	if a.Key == slog.TimeKey {
+		return slog.Attr{}
+	}
+	return a
+}


### PR DESCRIPTION
This can be overridden in the `litefs.yml` file:

```yml
log:
  timestamp: true
```