### PR TITLE
Compress LTX files sent to backup service

### DIFF
--- a/backup_client.go
+++ b/backup_client.go
@@ -255,6 +255,7 @@ func (c *FileBackupClient) FetchSnapshot(ctx context.Context, name string) (_ io
 	pr, pw := io.Pipe()
 	go func() {
 		compactor := ltx.NewCompactor(pw, rdrs)
+		compactor.HeaderFlags = ltx.HeaderFlagCompressLZ4
 		_ = pw.CloseWithError(compactor.Compact(ctx))
 	}()
 	return pr, nil

--- a/backup_client_test.go
+++ b/backup_client_test.go
@@ -71,14 +71,14 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 
 		// Verify contents of the snapshot.
 		if got, want := &other, (&ltx.FileSpec{
-			Header: ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 1, MaxTXID: 4},
+			Header: ltx.Header{Version: 1, Flags: ltx.HeaderFlagCompressLZ4, PageSize: 512, Commit: 2, MinTXID: 1, MaxTXID: 4},
 			Pages: []ltx.PageSpec{
 				{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{3}, 512)},
 				{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)},
 			},
 			Trailer: ltx.Trailer{
 				PostApplyChecksum: ltx.ChecksumFlag | 3000,
-				FileChecksum:      0xc8d8c55bde12fe8d,
+				FileChecksum:      0xbdc35cf8b5a3384c,
 			},
 		}); !reflect.DeepEqual(got, want) {
 			t.Fatalf("spec mismatch:\ngot:  %#v\nwant: %#v", got, want)

--- a/db.go
+++ b/db.go
@@ -1576,7 +1576,7 @@ func (db *DB) CommitWAL(ctx context.Context) (err error) {
 	enc := ltx.NewEncoder(ltxFile)
 	if err := enc.EncodeHeader(ltx.Header{
 		Version:          1,
-		Flags:            db.ltxHeaderFlags(),
+		Flags:            db.store.ltxHeaderFlags(),
 		PageSize:         db.pageSize,
 		Commit:           commit,
 		MinTXID:          txID,
@@ -1961,7 +1961,7 @@ func (db *DB) CommitJournal(ctx context.Context, mode JournalMode) (err error) {
 	enc := ltx.NewEncoder(ltxFile)
 	if err := enc.EncodeHeader(ltx.Header{
 		Version:          1,
-		Flags:            db.ltxHeaderFlags(),
+		Flags:            db.store.ltxHeaderFlags(),
 		PageSize:         db.pageSize,
 		Commit:           commit,
 		MinTXID:          txID,
@@ -2631,7 +2631,7 @@ func (db *DB) importToLTX(ctx context.Context, r io.Reader) (ltx.Pos, error) {
 	enc := ltx.NewEncoder(f)
 	if err := enc.EncodeHeader(ltx.Header{
 		Version:          1,
-		Flags:            db.ltxHeaderFlags(),
+		Flags:            db.store.ltxHeaderFlags(),
 		PageSize:         hdr.PageSize,
 		Commit:           hdr.PageN,
 		MinTXID:          pos.TXID,
@@ -3109,7 +3109,7 @@ func (db *DB) WriteSnapshotTo(ctx context.Context, dst io.Writer) (header ltx.He
 	enc := ltx.NewEncoder(dst)
 	if err := enc.EncodeHeader(ltx.Header{
 		Version:   ltx.Version,
-		Flags:     db.ltxHeaderFlags(),
+		Flags:     db.store.ltxHeaderFlags(),
 		PageSize:  pageSize,
 		Commit:    pageN,
 		MinTXID:   1,
@@ -3231,15 +3231,6 @@ func (db *DB) EnforceRetention(ctx context.Context, minTime time.Time) error {
 	dbLTXBytesMetricVec.WithLabelValues(db.name).Set(float64(totalSize))
 
 	return nil
-}
-
-// ltxHeaderFlags returns flags used for the LTX header.
-func (db *DB) ltxHeaderFlags() uint32 {
-	var flags uint32
-	if db.store.Compress {
-		flags |= ltx.HeaderFlagCompressLZ4
-	}
-	return flags
 }
 
 type dbVarJSON struct {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.16-0.20220918133448-90900be5db1a
 	github.com/prometheus/client_golang v1.13.0
 	github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b
-	github.com/superfly/ltx v0.3.3-0.20230516181327-9fabe139c9c8
+	github.com/superfly/ltx v0.3.3
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/sys v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,8 @@ github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b h1:+WuhtZFB8fNd
 github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b/go.mod h1:h+GUx1V2s0C5nY73ZN82760eWEJrpMaiDweF31VmJKk=
 github.com/superfly/ltx v0.3.3-0.20230516181327-9fabe139c9c8 h1:h7HBghgAmHDh4GnxZkEdb4hvDHsWBoD2oyDgQRAi0aA=
 github.com/superfly/ltx v0.3.3-0.20230516181327-9fabe139c9c8/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
+github.com/superfly/ltx v0.3.3 h1:dQANl4gg1loocCNEqUghOTPjeWMJySnGu9Sa3D5TVi8=
+github.com/superfly/ltx v0.3.3/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/store.go
+++ b/store.go
@@ -1006,6 +1006,7 @@ func (s *Store) streamBackupDB(ctx context.Context, name string, remotePos ltx.P
 	pr, pw := io.Pipe()
 	go func() {
 		compactor := ltx.NewCompactor(pw, rdrs)
+		compactor.HeaderFlags = s.ltxHeaderFlags()
 		_ = pw.CloseWithError(compactor.Compact(ctx))
 	}()
 
@@ -1369,6 +1370,15 @@ func (s *Store) processDropDBStreamFrame(ctx context.Context, frame *DropDBStrea
 		return fmt.Errorf("drop database: %w", err)
 	}
 	return nil
+}
+
+// ltxHeaderFlags returns flags used for the LTX header.
+func (s *Store) ltxHeaderFlags() uint32 {
+	var flags uint32
+	if s.Compress {
+		flags |= ltx.HeaderFlagCompressLZ4
+	}
+	return flags
 }
 
 // Expvar returns a variable for debugging output.


### PR DESCRIPTION
This pull request fixes the LTX compactor used to send changes to the backup service so it respects the `data.compress` flag in the config.