### PR TITLE
Implement cluster ID

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,7 +22,15 @@ type Client interface {
 	Commit(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64, r io.Reader) error
 
 	// Stream starts a long-running connection to stream changes from another node.
-	Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos) (io.ReadCloser, error)
+	Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos) (Stream, error)
+}
+
+// Stream represents a stream of frames.
+type Stream interface {
+	io.ReadCloser
+
+	// ClusterID of the primary node.
+	ClusterID() string
 }
 
 type StreamFrameType uint32

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"io"
 	"os"
+	"strings"
 )
 
 // Sync performs an fsync on the given path. Typically used for directories.
@@ -32,4 +33,18 @@ func ReadFullAt(r io.ReaderAt, buf []byte, off int64) (n int, err error) {
 		return n, io.ErrUnexpectedEOF
 	}
 	return n, err
+}
+
+// Close closes closer but ignores select errors.
+func Close(closer io.Closer) (err error) {
+	if closer == nil {
+		return nil
+	} else if err = closer.Close(); err == nil {
+		return nil
+	}
+
+	if strings.Contains(err.Error(), `use of closed network connection`) {
+		return nil
+	}
+	return err
 }

--- a/mock/client.go
+++ b/mock/client.go
@@ -14,7 +14,7 @@ type Client struct {
 	AcquireHaltLockFunc func(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) (*litefs.HaltLock, error)
 	ReleaseHaltLockFunc func(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) error
 	CommitFunc          func(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64, r io.Reader) error
-	StreamFunc          func(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos) (io.ReadCloser, error)
+	StreamFunc          func(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos) (litefs.Stream, error)
 }
 
 func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) (*litefs.HaltLock, error) {
@@ -29,6 +29,13 @@ func (c *Client) Commit(ctx context.Context, primaryURL string, nodeID uint64, n
 	return c.CommitFunc(ctx, primaryURL, nodeID, name, lockID, r)
 }
 
-func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos) (io.ReadCloser, error) {
+func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos) (litefs.Stream, error) {
 	return c.StreamFunc(ctx, primaryURL, nodeID, posMap)
 }
+
+type Stream struct {
+	io.ReadCloser
+	ClusterIDFunc func() string
+}
+
+func (s *Stream) ClusterID() string { return s.ClusterIDFunc() }

--- a/mock/lease.go
+++ b/mock/lease.go
@@ -15,11 +15,15 @@ type Leaser struct {
 	AcquireFunc         func(ctx context.Context) (litefs.Lease, error)
 	AcquireExistingFunc func(ctx context.Context, leaseID string) (litefs.Lease, error)
 	PrimaryInfoFunc     func(ctx context.Context) (litefs.PrimaryInfo, error)
+	ClusterIDFunc       func(ctx context.Context) (string, error)
+	SetClusterIDFunc    func(ctx context.Context, clusterID string) error
 }
 
 func (l *Leaser) Close() error {
 	return l.CloseFunc()
 }
+
+func (l *Leaser) Type() string { return "mock" }
 
 func (l *Leaser) AdvertiseURL() string {
 	return l.AdvertiseURLFunc()
@@ -35,6 +39,14 @@ func (l *Leaser) AcquireExisting(ctx context.Context, leaseID string) (litefs.Le
 
 func (l *Leaser) PrimaryInfo(ctx context.Context) (litefs.PrimaryInfo, error) {
 	return l.PrimaryInfoFunc(ctx)
+}
+
+func (l *Leaser) ClusterID(ctx context.Context) (string, error) {
+	return l.ClusterIDFunc(ctx)
+}
+
+func (l *Leaser) SetClusterID(ctx context.Context, clusterID string) error {
+	return l.SetClusterIDFunc(ctx, clusterID)
 }
 
 var _ litefs.Lease = (*Lease)(nil)


### PR DESCRIPTION
This pull request adds a "Cluster ID" to LiteFS clusters. This ID is generated when the first node becomes primary and it is then sent as an HTTP header to each connected replica. Replicas without a cluster ID set will adopt the cluster ID of the primary they connect to.

This change ensures that two existing clusters cannot accidentally join one another and delete one of the cluster's data.

Fixes https://github.com/superfly/litefs/issues/331