### PR TITLE
LiteFS Cloud environment variable

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -155,11 +155,12 @@ type LeaseConfig struct {
 
 // BackupConfig represents a config for backup services.
 type BackupConfig struct {
-	Type    string        `yaml:"type"`
-	Path    string        `yaml:"path"`    // "file" type only
-	URL     string        `yaml:"url"`     // "liteserver" type only
-	Cluster string        `yaml:"cluster"` // "liteserver" type only
-	Delay   time.Duration `yaml:"-"`
+	Type      string        `yaml:"type"`
+	Path      string        `yaml:"path"`       // "file" only
+	URL       string        `yaml:"url"`        // "litefs-cloud" only
+	Cluster   string        `yaml:"cluster"`    // "litefs-cloud" only
+	AuthToken string        `yaml:"auth-token"` // "litefs-cloud" only
+	Delay     time.Duration `yaml:"-"`
 }
 
 // LogConfig represents the configuration for logging.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -46,5 +46,8 @@ func Close(closer io.Closer) (err error) {
 	if strings.Contains(err.Error(), `use of closed network connection`) {
 		return nil
 	}
+	if strings.Contains(err.Error(), `http: Server closed`) {
+		return nil
+	}
 	return err
 }

--- a/lfsc/backup_client_test.go
+++ b/lfsc/backup_client_test.go
@@ -21,7 +21,7 @@ var integration = flag.Bool("integration", false, "run integration tests")
 
 func TestBackupClient_URL(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
-		c := lfsc.NewBackupClient(litefs.NewStore(t.TempDir(), true), url.URL{Scheme: "http", Host: "localhost:1234"}, "mycluster")
+		c := lfsc.NewBackupClient(litefs.NewStore(t.TempDir(), true), url.URL{Scheme: "http", Host: "localhost:1234"})
 		if got, want := c.URL(), `http://localhost:1234`; got != want {
 			t.Fatalf("URL=%s, want %s", got, want)
 		}
@@ -31,18 +31,11 @@ func TestBackupClient_URL(t *testing.T) {
 			Scheme: "http",
 			Host:   "localhost:1234",
 			Path:   "/foo/bar",
-		}, "mycluster")
+		})
 		if got, want := c.URL(), `http://localhost:1234`; got != want {
 			t.Fatalf("URL=%s, want %s", got, want)
 		}
 	})
-}
-
-func TestBackupClient_Cluster(t *testing.T) {
-	c := lfsc.NewBackupClient(litefs.NewStore(t.TempDir(), true), url.URL{Scheme: "http", Host: "localhost:1234"}, "mycluster")
-	if got, want := c.Cluster(), `mycluster`; got != want {
-		t.Fatalf("cluster=%s, want %s", got, want)
-	}
 }
 
 func TestBackupClient_WriteTx(t *testing.T) {
@@ -235,13 +228,13 @@ func newOpenBackupClient(tb testing.TB) *lfsc.BackupClient {
 	c := lfsc.NewBackupClient(
 		litefs.NewStore(tb.TempDir(), true),
 		url.URL{Scheme: "http", Host: "localhost:21212"},
-		fmt.Sprintf("test%d", rand.Intn(1000000)),
 	)
+	c.Cluster = fmt.Sprintf("test%d", rand.Intn(1000000))
 	if err := c.Open(); err != nil {
 		tb.Fatal(err)
 	}
 
-	tb.Logf("initializing client for test cluster: %s", c.Cluster())
+	tb.Logf("initializing client for test cluster: %q", c.Cluster)
 	return c
 }
 


### PR DESCRIPTION
This pull request automatically configures LiteFS Cloud when the `LITEFS_CLOUD_TOKEN` environment variable is set.

Fixes #334 