### PR TITLE
Position file mtime

### DIFF
--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -185,6 +185,18 @@ func (fsys *FileSystem) InvalidatePos(db *litefs.DB) error {
 	return nil
 }
 
+func (fsys *FileSystem) InvalidatePosAttr(db *litefs.DB) error {
+	node := fsys.root.Node(db.Name() + "-pos")
+	if node == nil {
+		return nil
+	}
+
+	if err := fsys.server.InvalidateNodeAttr(node); err != nil && err != fuse.ErrNotCached {
+		return err
+	}
+	return nil
+}
+
 // InvalidateEntry removes the file from the cache.
 func (fsys *FileSystem) InvalidateEntry(name string) error {
 	if err := fsys.server.InvalidateEntry(fsys.root, name); err != nil && err != fuse.ErrNotCached {

--- a/fuse/pos_node.go
+++ b/fuse/pos_node.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"syscall"
+	"time"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
@@ -39,6 +40,11 @@ func (n *PosNode) Attr(ctx context.Context, attr *fuse.Attr) error {
 	attr.Uid = uint32(n.fsys.Uid)
 	attr.Gid = uint32(n.fsys.Gid)
 	attr.Valid = 0
+
+	if lt := n.db.LastTouch(); !lt.Equal(time.UnixMilli(0)) {
+		attr.Mtime = lt
+	}
+
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,13 @@ go 1.20
 require (
 	bazil.org/fuse v0.0.0-20230120002735-62a210ff1fd5
 	github.com/hashicorp/consul/api v1.11.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mattn/go-sqlite3 v1.14.16-0.20220918133448-90900be5db1a
 	github.com/prometheus/client_golang v1.13.0
 	github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b
 	github.com/superfly/ltx v0.3.3
+	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/sys v0.4.0
@@ -23,11 +25,11 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-hclog v0.14.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
@@ -45,7 +47,6 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
-	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b h1:+WuhtZFB8fNdPeaMUtuB/U8aknXBXdDW/mBm/HTYJNg=
 github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b/go.mod h1:h+GUx1V2s0C5nY73ZN82760eWEJrpMaiDweF31VmJKk=
-github.com/superfly/ltx v0.3.3-0.20230516181327-9fabe139c9c8 h1:h7HBghgAmHDh4GnxZkEdb4hvDHsWBoD2oyDgQRAi0aA=
-github.com/superfly/ltx v0.3.3-0.20230516181327-9fabe139c9c8/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/superfly/ltx v0.3.3 h1:dQANl4gg1loocCNEqUghOTPjeWMJySnGu9Sa3D5TVi8=
 github.com/superfly/ltx v0.3.3/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/litefs.go
+++ b/litefs.go
@@ -209,6 +209,7 @@ type Invalidator interface {
 	InvalidateDBRange(db *DB, offset, size int64) error
 	InvalidateSHM(db *DB) error
 	InvalidatePos(db *DB) error
+	InvalidatePosAttr(db *DB) error
 	InvalidateEntry(name string) error
 }
 


### PR DESCRIPTION
This PR gives users the ability to calculate replication delay by looking at the mtime of the database pos file. Replicas update the mtime for all databases based on the timestamp from the latest message from the primary. Between sending ltx files, the primary sends periodic heartbeats to replicas containing the current timestamp.

The primary only updates the mtime when the actual position changes. It might be nicer to have the mtime on the primary always be the current time, but I didn't see an easy way to figure out if we're the primary in this part of the fuse code.

This PR doesn't have any tests yet, and is mostly a conversation starter. LMK if the idea seems sound and I can add some tests.