### PR TITLE
Set mtime on pos file using timestamp from last ltx

### DIFF
--- a/fuse/pos_node.go
+++ b/fuse/pos_node.go
@@ -40,6 +40,7 @@ func (n *PosNode) Attr(ctx context.Context, attr *fuse.Attr) error {
 	attr.Uid = uint32(n.fsys.Uid)
 	attr.Gid = uint32(n.fsys.Gid)
 	attr.Valid = 0
+	attr.Mtime = n.db.Timestamp()
 	return nil
 }
 


### PR DESCRIPTION
This doesn't bother with the heartbeats from https://github.com/superfly/litefs/pull/340 and just sets the mtime on the pos file based on the timestamp from the latest ltx.