### PR TITLE
Refactor SHM file access through FUSE

### DIFF
--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -348,7 +348,7 @@ func (c *MountCommand) initConsul(ctx context.Context) (err error) {
 }
 
 func (c *MountCommand) initStore(ctx context.Context) error {
-	c.Store = litefs.NewStore(c.Config.Data.Dir, c.Config.Lease.Candidate)
+	c.Store = litefs.NewStore(c.Config.Data.Dir, c.Config.FUSE.Dir, c.Config.Lease.Candidate)
 	c.Store.StrictVerify = c.Config.StrictVerify
 	c.Store.Compress = c.Config.Data.Compress
 	c.Store.Retention = c.Config.Data.Retention

--- a/db.go
+++ b/db.go
@@ -37,6 +37,7 @@ type DB struct {
 	pos      atomic.Value  // current tx position (Pos)
 	hwm      atomic.Uint64 // high-water mark
 	mode     atomic.Value  // database journaling mode (rollback, wal)
+	opened   bool          // if true, the Open() function has completed
 	// waiting  atomic.Bool  // if true, database is waiting to catch up for a remote tx
 
 	// Halt lock prevents writes or checkpoints on the primary so that
@@ -60,7 +61,6 @@ type DB struct {
 		frameOffsets     map[uint32]int64    // WAL frame offset of the last version of a given pgno before current tx
 		chksums          map[uint32][]uint64 // wal page checksums
 	}
-	shmMu sync.Mutex // shm invalidation can trigger mmap write that we need to avoid
 
 	// Collection of outstanding guard sets, protected by a mutex.
 	guardSets struct {
@@ -158,8 +158,11 @@ func (db *DB) JournalPath() string { return filepath.Join(db.path, "journal") }
 // WALPath returns the path to the underlying WAL file.
 func (db *DB) WALPath() string { return filepath.Join(db.path, "wal") }
 
-// SHMPath returns the path to the underlying shared memory file.
-func (db *DB) SHMPath() string { return filepath.Join(db.path, "shm") }
+// MountedSHMPath returns the path to the shared memory file on the mounted directory.
+func (db *DB) MountedSHMPath() string { return filepath.Join(db.store.mountDir, db.name+"-shm") }
+
+// InternalSHMPath returns the path to the shared memory file in the data directory.
+func (db *DB) InternalSHMPath() string { return filepath.Join(db.path, "shm") }
 
 // Pos returns the current transaction position of the database.
 func (db *DB) Pos() ltx.Pos {
@@ -478,7 +481,7 @@ func (db *DB) Open() error {
 	}
 
 	// Remove all SHM files on start up.
-	if err := os.Remove(db.SHMPath()); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(db.InternalSHMPath()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove shm: %w", err)
 	}
 
@@ -512,6 +515,8 @@ func (db *DB) Open() error {
 			return fmt.Errorf("recover ltx: %w", err)
 		}
 	}
+
+	db.opened = true
 
 	return nil
 }
@@ -1777,14 +1782,14 @@ func (db *DB) readPage(dbFile, walFile *os.File, pgno uint32, buf []byte) error 
 
 // CreateSHM creates a new shared memory file on disk.
 func (db *DB) CreateSHM() (*os.File, error) {
-	f, err := os.OpenFile(db.SHMPath(), os.O_RDWR|os.O_CREATE|os.O_EXCL|os.O_TRUNC, 0o666)
+	f, err := os.OpenFile(db.InternalSHMPath(), os.O_RDWR|os.O_CREATE|os.O_EXCL|os.O_TRUNC, 0o666)
 	TraceLog.Printf("%s [CreateSHM(%s)]: %s", db.store.LogPrefix(), db.name, errorKeyValue(err))
 	return f, err
 }
 
 // OpenSHM returns a handle for the shared memory file.
 func (db *DB) OpenSHM(ctx context.Context) (*os.File, error) {
-	f, err := os.OpenFile(db.SHMPath(), os.O_RDWR, 0o666)
+	f, err := os.OpenFile(db.InternalSHMPath(), os.O_RDWR|os.O_CREATE, 0o666)
 	TraceLog.Printf("%s [OpenSHM(%s)]: %s", db.store.LogPrefix(), db.name, errorKeyValue(err))
 	return f, err
 }
@@ -1802,7 +1807,7 @@ func (db *DB) SyncSHM(ctx context.Context) (err error) {
 		TraceLog.Printf("%s [SyncSHM(%s)]: %s", db.store.LogPrefix(), db.name, errorKeyValue(err))
 	}()
 
-	f, err := os.Open(db.SHMPath())
+	f, err := os.Open(db.InternalSHMPath())
 	if err != nil {
 		return err
 	} else if err := f.Sync(); err != nil {
@@ -1814,14 +1819,14 @@ func (db *DB) SyncSHM(ctx context.Context) (err error) {
 
 // TruncateSHM sets the size of the the SHM file.
 func (db *DB) TruncateSHM(ctx context.Context, size int64) error {
-	err := os.Truncate(db.SHMPath(), size)
+	err := os.Truncate(db.InternalSHMPath(), size)
 	TraceLog.Printf("%s [TruncateSHM(%s)]: size=%d %s", db.store.LogPrefix(), db.name, size, errorKeyValue(err))
 	return err
 }
 
 // RemoveSHM removes the SHM file from disk.
 func (db *DB) RemoveSHM(ctx context.Context) error {
-	err := os.Remove(db.SHMPath())
+	err := os.Remove(db.InternalSHMPath())
 	TraceLog.Printf("%s [RemoveSHM(%s)]: %s", db.store.LogPrefix(), db.name, errorKeyValue(err))
 	return err
 }
@@ -1853,14 +1858,6 @@ func (db *DB) ReadSHMAt(ctx context.Context, f *os.File, data []byte, offset int
 
 // WriteSHMAt writes data to the SHM file.
 func (db *DB) WriteSHMAt(ctx context.Context, f *os.File, data []byte, offset int64, owner uint64) (int, error) {
-	// Ignore writes that occur while the SHM is updating. This is a side effect
-	// of SQLite using mmap() which can cause re-access to update it.
-	if !db.shmMu.TryLock() {
-		TraceLog.Printf("%s [WriteSHMAt(%s)]: offset=%d size=%d [BLOCKED]", db.store.LogPrefix(), db.name, offset, len(data))
-		return len(data), nil
-	}
-	defer db.shmMu.Unlock()
-
 	dbSHMWriteCountMetricVec.WithLabelValues(db.name).Inc()
 	n, err := f.WriteAt(data, offset)
 	TraceLog.Printf("%s [WriteSHMAt(%s)]: offset=%d size=%d owner=%d %s", db.store.LogPrefix(), db.name, offset, len(data), owner, errorKeyValue(err))
@@ -2391,16 +2388,19 @@ func (db *DB) ApplyLTXNoLock(ctx context.Context, path string) error {
 
 // updateSHM recomputes the SHM header for a replica node (with no WAL frames).
 func (db *DB) updateSHM(ctx context.Context) error {
-	// This lock prevents an issue where triggering SHM invalidation in FUSE
-	// causes a write to be issued through the mmap which overwrites our change.
-	// This lock blocks that from occurring.
-	db.shmMu.Lock()
-	defer db.shmMu.Unlock()
-
 	TraceLog.Printf("%s [UpdateSHM(%s)]", db.store.LogPrefix(), db.name)
 	defer TraceLog.Printf("%s [UpdateSHMDone(%s)]", db.store.LogPrefix(), db.name)
 
-	f, err := os.OpenFile(db.SHMPath(), os.O_RDWR|os.O_CREATE, 0o666)
+	// Use the internal SHM path if we haven't finished initializing the database
+	// since we won't have the mount directory available yet.
+	shmPath := db.MountedSHMPath()
+	if !db.opened {
+		shmPath = db.InternalSHMPath()
+	}
+
+	// We must access the SHM file through the mount because SQLite uses it through
+	// mmap() and this causes race conditions with syncing on the FUSE side.
+	f, err := os.OpenFile(shmPath, os.O_RDWR|os.O_CREATE, 0o666)
 	if err != nil {
 		return err
 	}
@@ -2442,13 +2442,6 @@ func (db *DB) updateSHM(ctx context.Context) error {
 		return err
 	} else if err := f.Truncate(int64(len(data))); err != nil {
 		return err
-	}
-
-	// Invalidate page cache.
-	if invalidator := db.store.Invalidator; invalidator != nil {
-		if err := invalidator.InvalidateSHM(db); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -878,7 +878,8 @@ func TestFileSystem_HaltLock(t *testing.T) {
 func newFileSystem(tb testing.TB, path string, leaser litefs.Leaser) *fuse.FileSystem {
 	tb.Helper()
 
-	store := litefs.NewStore(filepath.Join(path, "data"), true)
+	mountDir := filepath.Join(path, "mnt")
+	store := litefs.NewStore(filepath.Join(path, "data"), mountDir, true)
 	store.StrictVerify = true
 	store.Compress = testingutil.Compress()
 	store.Leaser = leaser
@@ -886,7 +887,7 @@ func newFileSystem(tb testing.TB, path string, leaser litefs.Leaser) *fuse.FileS
 		tb.Fatalf("cannot open store: %s", err)
 	}
 
-	fs := fuse.NewFileSystem(filepath.Join(path, "mnt"), store)
+	fs := fuse.NewFileSystem(mountDir, store)
 	fs.Debug = *fuseDebug
 
 	store.Invalidator = fs

--- a/fuse/root_node.go
+++ b/fuse/root_node.go
@@ -16,17 +16,19 @@ import (
 
 const RootInode = 1
 
-var _ fs.Node = (*RootNode)(nil)
-var _ fs.NodeStringLookuper = (*RootNode)(nil)
-var _ fs.NodeOpener = (*RootNode)(nil)
-var _ fs.NodeCreater = (*RootNode)(nil)
-var _ fs.NodeRemover = (*RootNode)(nil)
-var _ fs.NodeFsyncer = (*RootNode)(nil)
-var _ fs.NodeListxattrer = (*RootNode)(nil)
-var _ fs.NodeGetxattrer = (*RootNode)(nil)
-var _ fs.NodeSetxattrer = (*RootNode)(nil)
-var _ fs.NodeRemovexattrer = (*RootNode)(nil)
-var _ fs.NodePoller = (*RootNode)(nil)
+var (
+	_ fs.Node               = (*RootNode)(nil)
+	_ fs.NodeStringLookuper = (*RootNode)(nil)
+	_ fs.NodeOpener         = (*RootNode)(nil)
+	_ fs.NodeCreater        = (*RootNode)(nil)
+	_ fs.NodeRemover        = (*RootNode)(nil)
+	_ fs.NodeFsyncer        = (*RootNode)(nil)
+	_ fs.NodeListxattrer    = (*RootNode)(nil)
+	_ fs.NodeGetxattrer     = (*RootNode)(nil)
+	_ fs.NodeSetxattrer     = (*RootNode)(nil)
+	_ fs.NodeRemovexattrer  = (*RootNode)(nil)
+	_ fs.NodePoller         = (*RootNode)(nil)
+)
 
 // RootNode represents the root directory of the FUSE mount.
 type RootNode struct {
@@ -55,9 +57,9 @@ func (n *RootNode) Attr(ctx context.Context, attr *fuse.Attr) error {
 	attr.Inode = RootInode
 
 	if n.fsys.store.IsPrimary() {
-		attr.Mode = os.ModeDir | 0777
+		attr.Mode = os.ModeDir | 0o777
 	} else {
-		attr.Mode = os.ModeDir | 0555
+		attr.Mode = os.ModeDir | 0o555
 	}
 
 	attr.Uid = uint32(n.fsys.Uid)
@@ -129,7 +131,7 @@ func (n *RootNode) lookupDBNode(ctx context.Context, name string) (fs.Node, erro
 		return newWALNode(n.fsys, db), nil
 
 	case litefs.FileTypeSHM:
-		if _, err := os.Stat(db.SHMPath()); os.IsNotExist(err) {
+		if _, err := os.Stat(db.InternalSHMPath()); os.IsNotExist(err) {
 			return nil, syscall.ENOENT
 		} else if err != nil {
 			return nil, err
@@ -349,8 +351,10 @@ func (n *RootNode) Poll(ctx context.Context, req *fuse.PollRequest, resp *fuse.P
 	return fuse.Errno(syscall.ENOSYS)
 }
 
-var _ fs.Handle = (*RootHandle)(nil)
-var _ fs.HandleReadDirAller = (*RootHandle)(nil)
+var (
+	_ fs.Handle             = (*RootHandle)(nil)
+	_ fs.HandleReadDirAller = (*RootHandle)(nil)
+)
 
 // RootHandle represents a directory handle for the root directory.
 type RootHandle struct {
@@ -392,7 +396,7 @@ func (h *RootHandle) ReadDirAll(ctx context.Context) (ents []fuse.Dirent, err er
 				Type: fuse.DT_File,
 			})
 		}
-		if _, err := os.Stat(db.SHMPath()); err == nil {
+		if _, err := os.Stat(db.InternalSHMPath()); err == nil {
 			ents = append(ents, fuse.Dirent{
 				Name: fmt.Sprintf("%s-shm", db.Name()),
 				Type: fuse.DT_File,

--- a/fuse/shm_node.go
+++ b/fuse/shm_node.go
@@ -12,15 +12,17 @@ import (
 	"github.com/superfly/litefs"
 )
 
-var _ fs.Node = (*SHMNode)(nil)
-var _ fs.NodeOpener = (*SHMNode)(nil)
-var _ fs.NodeFsyncer = (*SHMNode)(nil)
-var _ fs.NodeForgetter = (*SHMNode)(nil)
-var _ fs.NodeListxattrer = (*SHMNode)(nil)
-var _ fs.NodeGetxattrer = (*SHMNode)(nil)
-var _ fs.NodeSetxattrer = (*SHMNode)(nil)
-var _ fs.NodeRemovexattrer = (*SHMNode)(nil)
-var _ fs.NodePoller = (*SHMNode)(nil)
+var (
+	_ fs.Node              = (*SHMNode)(nil)
+	_ fs.NodeOpener        = (*SHMNode)(nil)
+	_ fs.NodeFsyncer       = (*SHMNode)(nil)
+	_ fs.NodeForgetter     = (*SHMNode)(nil)
+	_ fs.NodeListxattrer   = (*SHMNode)(nil)
+	_ fs.NodeGetxattrer    = (*SHMNode)(nil)
+	_ fs.NodeSetxattrer    = (*SHMNode)(nil)
+	_ fs.NodeRemovexattrer = (*SHMNode)(nil)
+	_ fs.NodePoller        = (*SHMNode)(nil)
+)
 
 // SHMNode represents a SQLite database file.
 type SHMNode struct {
@@ -36,14 +38,14 @@ func newSHMNode(fsys *FileSystem, db *litefs.DB) *SHMNode {
 }
 
 func (n *SHMNode) Attr(ctx context.Context, attr *fuse.Attr) error {
-	fi, err := os.Stat(n.db.SHMPath())
+	fi, err := os.Stat(n.db.InternalSHMPath())
 	if os.IsNotExist(err) {
 		return syscall.ENOENT
 	} else if err != nil {
 		return err
 	}
 
-	attr.Mode = 0666
+	attr.Mode = 0o666
 	attr.Size = uint64(fi.Size())
 	attr.Uid = uint32(n.fsys.Uid)
 	attr.Gid = uint32(n.fsys.Gid)
@@ -100,10 +102,12 @@ func (n *SHMNode) Poll(ctx context.Context, req *fuse.PollRequest, resp *fuse.Po
 	return fuse.Errno(syscall.ENOSYS)
 }
 
-var _ fs.Handle = (*SHMHandle)(nil)
-var _ fs.HandleReader = (*SHMHandle)(nil)
-var _ fs.HandleWriter = (*SHMHandle)(nil)
-var _ fs.HandlePOSIXLocker = (*SHMHandle)(nil)
+var (
+	_ fs.Handle            = (*SHMHandle)(nil)
+	_ fs.HandleReader      = (*SHMHandle)(nil)
+	_ fs.HandleWriter      = (*SHMHandle)(nil)
+	_ fs.HandlePOSIXLocker = (*SHMHandle)(nil)
+)
 
 // SHMHandle represents a file handle to a SQLite database file.
 type SHMHandle struct {

--- a/lfsc/backup_client_test.go
+++ b/lfsc/backup_client_test.go
@@ -21,13 +21,13 @@ var integration = flag.Bool("integration", false, "run integration tests")
 
 func TestBackupClient_URL(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
-		c := lfsc.NewBackupClient(litefs.NewStore(t.TempDir(), true), url.URL{Scheme: "http", Host: "localhost:1234"})
+		c := lfsc.NewBackupClient(litefs.NewStore(t.TempDir(), t.TempDir(), true), url.URL{Scheme: "http", Host: "localhost:1234"})
 		if got, want := c.URL(), `http://localhost:1234`; got != want {
 			t.Fatalf("URL=%s, want %s", got, want)
 		}
 	})
 	t.Run("Strip", func(t *testing.T) {
-		c := lfsc.NewBackupClient(litefs.NewStore(t.TempDir(), true), url.URL{
+		c := lfsc.NewBackupClient(litefs.NewStore(t.TempDir(), t.TempDir(), true), url.URL{
 			Scheme: "http",
 			Host:   "localhost:1234",
 			Path:   "/foo/bar",
@@ -226,7 +226,7 @@ func newOpenBackupClient(tb testing.TB) *lfsc.BackupClient {
 	}
 
 	c := lfsc.NewBackupClient(
-		litefs.NewStore(tb.TempDir(), true),
+		litefs.NewStore(tb.TempDir(), tb.TempDir(), true),
 		url.URL{Scheme: "http", Host: "localhost:21212"},
 	)
 	c.Cluster = fmt.Sprintf("test%d", rand.Intn(1000000))

--- a/store_test.go
+++ b/store_test.go
@@ -174,7 +174,7 @@ func TestStore_ID(t *testing.T) {
 	}
 
 	// Reopen as a new instance.
-	store = litefs.NewStore(store.Path(), true)
+	store = litefs.NewStore(store.Path(), store.MountDir(), true)
 	store.Leaser = newPrimaryStaticLeaser()
 	if err := store.Open(); err != nil {
 		t.Fatal(err)
@@ -309,7 +309,7 @@ func TestStore_PrimaryCtx(t *testing.T) {
 // newStore returns a new instance of a Store on a temporary directory.
 // This store will automatically close when the test ends.
 func newStore(tb testing.TB, leaser litefs.Leaser, client litefs.Client) *litefs.Store {
-	store := litefs.NewStore(tb.TempDir(), true)
+	store := litefs.NewStore(tb.TempDir(), tb.TempDir(), true)
 	store.Leaser = leaser
 	store.Client = client
 	tb.Cleanup(func() {


### PR DESCRIPTION
This pull request changes the internal access of the SHM file to run through the FUSE mount to avoid timing issues with the mmap() access from SQLite.

Note: This is currently failing on `TestMultiNode_DropDB` because there's some kind of invalidation issue on the SHM file. 

Fixes #346 