### PR TITLE
Wait for SHM changes to flush before exit

### DIFF
--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -182,14 +182,15 @@ func (c *MountCommand) Close() (err error) {
 		}
 	}
 
-	if c.FileSystem != nil {
-		if e := c.FileSystem.Unmount(); err == nil {
+	if c.Store != nil {
+		c.Store.SetMountReady(false)
+		if e := c.Store.Close(); err == nil {
 			err = e
 		}
 	}
 
-	if c.Store != nil {
-		if e := c.Store.Close(); err == nil {
+	if c.FileSystem != nil {
+		if e := c.FileSystem.Unmount(); err == nil {
 			err = e
 		}
 	}
@@ -450,6 +451,7 @@ func (c *MountCommand) initFileSystem(ctx context.Context) error {
 
 	// Attach file system to store so it can invalidate the page cache.
 	c.Store.Invalidator = fsys
+	c.Store.SetMountReady(true)
 
 	c.FileSystem = fsys
 	return nil

--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -1663,6 +1663,7 @@ func TestMultiNode_Handoff(t *testing.T) {
 	cmd0 := runMountCommand(t, newMountCommand(t, t.TempDir(), nil))
 	waitForPrimary(t, cmd0)
 	cmd1 := runMountCommand(t, newMountCommand(t, t.TempDir(), cmd0))
+
 	db0 := testingutil.OpenSQLDB(t, filepath.Join(cmd0.Config.FUSE.Dir, "db"))
 	db1 := testingutil.OpenSQLDB(t, filepath.Join(cmd1.Config.FUSE.Dir, "db"))
 

--- a/db.go
+++ b/db.go
@@ -2394,15 +2394,19 @@ func (db *DB) ApplyLTXNoLock(ctx context.Context, path string) error {
 
 // updateSHM recomputes the SHM header for a replica node (with no WAL frames).
 func (db *DB) updateSHM(ctx context.Context) error {
-	TraceLog.Printf("%s [UpdateSHM(%s)]", db.store.LogPrefix(), db.name)
-	defer TraceLog.Printf("%s [UpdateSHMDone(%s)]", db.store.LogPrefix(), db.name)
+	if db.Mode() != DBModeWAL {
+		return nil
+	}
 
 	// Use the internal SHM path if we haven't finished initializing the database
 	// since we won't have the mount directory available yet.
 	shmPath := db.MountedSHMPath()
-	if !db.opened {
+	if !db.store.MountReady() {
 		shmPath = db.InternalSHMPath()
 	}
+
+	TraceLog.Printf("%s [UpdateSHM(%s)] ptr=%p path=%s", db.store.LogPrefix(), db.name, db, shmPath)
+	defer TraceLog.Printf("%s [UpdateSHMDone(%s)]", db.store.LogPrefix(), db.name)
 
 	// We must access the SHM file through the mount because SQLite uses it through
 	// mmap() and this causes race conditions with syncing on the FUSE side.
@@ -2447,6 +2451,9 @@ func (db *DB) updateSHM(ctx context.Context) error {
 	if _, err := f.WriteAt(data, 0); err != nil {
 		return err
 	} else if err := f.Truncate(int64(len(data))); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
 		return err
 	}
 

--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -5,15 +5,18 @@ import (
 	"log"
 	"os"
 	"syscall"
+	"time"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"github.com/superfly/litefs"
 )
 
-var _ fs.FS = (*FileSystem)(nil)
-var _ fs.FSStatfser = (*FileSystem)(nil)
-var _ litefs.Invalidator = (*FileSystem)(nil)
+var (
+	_ fs.FS              = (*FileSystem)(nil)
+	_ fs.FSStatfser      = (*FileSystem)(nil)
+	_ litefs.Invalidator = (*FileSystem)(nil)
+)
 
 // FileSystem represents a raw interface to the FUSE file system.
 type FileSystem struct {
@@ -63,7 +66,7 @@ func (fsys *FileSystem) Mount() (err error) {
 	_ = fuse.Unmount(fsys.path)
 
 	// Ensure mount directory exists before trying to mount to it.
-	if err := os.MkdirAll(fsys.path, 0777); err != nil {
+	if err := os.MkdirAll(fsys.path, 0o777); err != nil {
 		return err
 	}
 
@@ -99,10 +102,28 @@ func (fsys *FileSystem) Mount() (err error) {
 // Unmount unmounts the file system.
 func (fsys *FileSystem) Unmount() (err error) {
 	if fsys.conn != nil {
+		conn := fsys.conn
+		fsys.conn = nil
+
 		if e := fuse.Unmount(fsys.path); err == nil {
 			err = e
 		}
-		fsys.conn = nil
+
+		closed := make(chan error, 1)
+		go func() {
+			closed <- conn.Close()
+		}()
+
+		// Wait for the FUSE connection to close but don't wait indefinitely.
+		// This can cause the process to hang and it eventually gets cleaned
+		// up when the process exits anyway.
+		select {
+		case e := <-closed:
+			if err == nil {
+				err = e
+			}
+		case <-time.After(1 * time.Second):
+		}
 	}
 	return err
 }

--- a/store.go
+++ b/store.go
@@ -57,6 +57,7 @@ type Store struct {
 	dbs              map[string]*DB
 	subscribers      map[*Subscriber]struct{}
 	primaryTimestamp atomic.Int64 // ms since epoch of last update from primary. -1 if primary
+	mountReady       atomic.Bool  // if true, SHM can be accessed through FUSE mount
 
 	lease       Lease         // if not nil, store is current primary
 	primaryCh   chan struct{} // closed when primary loses leadership
@@ -224,6 +225,12 @@ func (s *Store) setClusterID(id string) error {
 	s.clusterID.Store(id)
 	return nil
 }
+
+// SetMountReady marks the FUSE mount as ready to use for SHM access.
+func (s *Store) SetMountReady(v bool) { s.mountReady.Store(v) }
+
+// MountReady returns true if the FUSE mount is marked as ready.
+func (s *Store) MountReady() bool { return s.mountReady.Load() }
 
 // LogPrefix returns the primary status and the store ID.
 func (s *Store) LogPrefix() string {


### PR DESCRIPTION
When the SHM access was changed to go through the FUSE mount (#346), this caused a race condition on FUSE shutdown for pending changes to the SHM. The FUSE connection is now explicitly closed and internal changes to SHM are sync'd to FUSE. There is also a "mount ready" flag on the store to indicate when the FUSE mount is available so that the store does not attempt to access it before mount or after unmount.