### PR TITLE
Set host environment metadata

### DIFF
--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mattn/go-shellwords"
 	"github.com/superfly/litefs"
 	"github.com/superfly/litefs/consul"
+	"github.com/superfly/litefs/fly"
 	"github.com/superfly/litefs/fuse"
 	"github.com/superfly/litefs/http"
 	"github.com/superfly/litefs/lfsc"
@@ -356,11 +357,22 @@ func (c *MountCommand) initStore(ctx context.Context) error {
 	c.Store.ReconnectDelay = c.Config.Lease.ReconnectDelay
 	c.Store.DemoteDelay = c.Config.Lease.DemoteDelay
 	c.Store.Client = http.NewClient()
+	c.initEnvironment(ctx)
 
 	if err := c.initStoreBackupClient(ctx); err != nil {
 		return err
 	}
 	return nil
+}
+
+func (c *MountCommand) initEnvironment(ctx context.Context) {
+	if fly.Available() {
+		c.Store.Environment = fly.NewEnvironment()
+	}
+
+	if typ := c.Store.Environment.Type(); typ != "" {
+		slog.Info("host environment detected", slog.String("type", typ))
+	}
 }
 
 func (c *MountCommand) initStoreBackupClient(ctx context.Context) error {

--- a/fly/environment.go
+++ b/fly/environment.go
@@ -1,0 +1,105 @@
+package fly
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strconv"
+	"time"
+
+	"golang.org/x/exp/slog"
+)
+
+const DefaultTimeout = 2 * time.Second
+
+type Environment struct {
+	HTTPClient *http.Client
+
+	Timeout time.Duration
+}
+
+func NewEnvironment() *Environment {
+	return &Environment{
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					return net.Dial("unix", "/.fly/api")
+				},
+			},
+		},
+		Timeout: DefaultTimeout,
+	}
+}
+
+func (e *Environment) Type() string { return "fly.io" }
+
+func (e *Environment) SetPrimaryStatus(ctx context.Context, v bool) error {
+	appName := AppName()
+	if appName == "" {
+		slog.Info("cannot set primary status on host environment", slog.String("reason", "app name unavailable"))
+		return nil
+	}
+
+	machineID := MachineID()
+	if machineID == "" {
+		slog.Info("cannot set primary status on host environment", slog.String("reason", "machine id unavailable"))
+		return nil
+	}
+
+	reqBody, err := json.Marshal(postMetadataRequest{
+		Value: strconv.FormatBool(v),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal metadata request body: %w", err)
+	}
+
+	u := url.URL{
+		Scheme: "http",
+		Host:   "localhost",
+		Path:   path.Join("/v1", "apps", appName, "machines", machineID, "metadata", "primary"),
+	}
+	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(reqBody))
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, e.Timeout)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	resp, err := e.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusNoContent:
+		return nil
+	default:
+		return fmt.Errorf("cannot set machine metadata: code=%d", resp.StatusCode)
+	}
+}
+
+type postMetadataRequest struct {
+	Value string `json:"value"`
+}
+
+// Available returns true if currently running in a Fly.io environment.
+func Available() bool { return AppName() != "" }
+
+// AppName returns the name of the current Fly.io application.
+func AppName() string {
+	return os.Getenv("FLY_APP_NAME")
+}
+
+// MachineID returns the identifier for the current Fly.io machine.
+func MachineID() string {
+	return os.Getenv("FLY_MACHINE_ID")
+}

--- a/litefs.go
+++ b/litefs.go
@@ -2,6 +2,7 @@ package litefs
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/json"
@@ -99,6 +100,21 @@ func (i *NodeInfo) UnmarshalJSON(data []byte) (err error) {
 	i.Path = v.Path
 	return nil
 }
+
+// Environment represents an interface for interacting with the host environment.
+type Environment interface {
+	// Type returns the name of the environment type.
+	Type() string
+
+	// SetPrimaryStatus sets marks the current node as the primary or not.
+	SetPrimaryStatus(ctx context.Context, isPrimary bool) error
+}
+
+type nopEnvironment struct{}
+
+func (*nopEnvironment) Type() string { return "" }
+
+func (*nopEnvironment) SetPrimaryStatus(ctx context.Context, v bool) error { return nil }
 
 // NativeEndian is always set to little endian as that is the only endianness
 // used by supported platforms for LiteFS. This may be expanded in the future.


### PR DESCRIPTION
This pull request adds an `Environment` interface for interacting with the host environment and adds an implementation for Fly Machines although other environments can be added in the future.

Fixes #356 