### PR TITLE
Periodically check backup server for updates

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -53,6 +53,7 @@ func NewConfig() Config {
 	config.Lease.DemoteDelay = litefs.DefaultDemoteDelay
 
 	config.Backup.Delay = litefs.DefaultBackupDelay
+	config.Backup.FullSyncInterval = litefs.DefaultBackupFullSyncInterval
 
 	config.Log.Format = "text"
 
@@ -155,12 +156,13 @@ type LeaseConfig struct {
 
 // BackupConfig represents a config for backup services.
 type BackupConfig struct {
-	Type      string        `yaml:"type"`
-	Path      string        `yaml:"path"`       // "file" only
-	URL       string        `yaml:"url"`        // "litefs-cloud" only
-	Cluster   string        `yaml:"cluster"`    // "litefs-cloud" only
-	AuthToken string        `yaml:"auth-token"` // "litefs-cloud" only
-	Delay     time.Duration `yaml:"-"`
+	Type             string        `yaml:"type"`
+	Path             string        `yaml:"path"`       // "file" only
+	URL              string        `yaml:"url"`        // "litefs-cloud" only
+	Cluster          string        `yaml:"cluster"`    // "litefs-cloud" only
+	AuthToken        string        `yaml:"auth-token"` // "litefs-cloud" only
+	Delay            time.Duration `yaml:"-"`
+	FullSyncInterval time.Duration `yaml:"-"`
 }
 
 // LogConfig represents the configuration for logging.

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -378,6 +378,10 @@ func (c *MountCommand) initEnvironment(ctx context.Context) {
 func (c *MountCommand) initStoreBackupClient(ctx context.Context) error {
 	c.initBackupConfigFromEnv(ctx)
 
+	// Copy common fields.
+	c.Store.BackupDelay = c.Config.Backup.Delay
+	c.Store.BackupFullSyncInterval = c.Config.Backup.FullSyncInterval
+
 	switch typ := c.Config.Backup.Type; typ {
 	case "":
 		log.Printf("no backup client configured, skipping")


### PR DESCRIPTION
This pull request adds a "full sync" interval to the backup client so that it will recheck the position on the backup server periodically. This ensures that a cluster can be restored to an old state even in the absence of active writes on the database.