### PR TITLE
Retry environment metadata updates

### DIFF
--- a/litefs.go
+++ b/litefs.go
@@ -107,14 +107,14 @@ type Environment interface {
 	Type() string
 
 	// SetPrimaryStatus sets marks the current node as the primary or not.
-	SetPrimaryStatus(ctx context.Context, isPrimary bool) error
+	SetPrimaryStatus(ctx context.Context, isPrimary bool)
 }
 
 type nopEnvironment struct{}
 
 func (*nopEnvironment) Type() string { return "" }
 
-func (*nopEnvironment) SetPrimaryStatus(ctx context.Context, v bool) error { return nil }
+func (*nopEnvironment) SetPrimaryStatus(ctx context.Context, v bool) {}
 
 // NativeEndian is always set to little endian as that is the only endianness
 // used by supported platforms for LiteFS. This may be expanded in the future.

--- a/store.go
+++ b/store.go
@@ -714,9 +714,7 @@ func (s *Store) markDirty(name string) {
 // monitorLease continuously handles either the leader lease or replicates from the primary.
 func (s *Store) monitorLease(ctx context.Context) (err error) {
 	// Initialize environment to indicate this node is not a primary.
-	if err := s.Environment.SetPrimaryStatus(ctx, false); err != nil {
-		slog.Info("cannot init primary status on host environment", slog.Any("err", err))
-	}
+	s.Environment.SetPrimaryStatus(ctx, false)
 
 	var handoffLeaseID string
 	for {
@@ -918,14 +916,8 @@ func (s *Store) monitorLeaseAsPrimary(ctx context.Context, lease Lease) error {
 	}()
 
 	// Notify host environment that we are primary.
-	if err := s.Environment.SetPrimaryStatus(ctx, true); err != nil {
-		slog.Info("cannot set primary status on host environment", slog.Any("err", err))
-	}
-	defer func() {
-		if err := s.Environment.SetPrimaryStatus(ctx, false); err != nil {
-			slog.Info("cannot unset primary status on host environment", slog.Any("err", err))
-		}
-	}()
+	s.Environment.SetPrimaryStatus(ctx, true)
+	defer func() { s.Environment.SetPrimaryStatus(ctx, false) }()
 
 	waitDur := lease.TTL() / 2
 


### PR DESCRIPTION
This pull request changes `Environment.SetPrimaryStatus()` so that it is non-blocking, it retries five times on failure, and it change some error messages to report `DEBUG` instead of `INFO`. The environment metadata is not critical to correctness so we can lower the error severity.

Fixes #363, #364 