### PR TITLE
Return 503 from proxy when no primary available

### DIFF
--- a/http/proxy_server.go
+++ b/http/proxy_server.go
@@ -241,8 +241,8 @@ func (s *ProxyServer) serveNonRead(w http.ResponseWriter, r *http.Request) {
 	// Look up the hostname of the primary. If there's no primary info then
 	// go ahead and send the request
 	if info == nil {
-		s.logf("proxy: %s %s: no primary available, proxying to target", r.Method, r.URL.Path)
-		s.proxyToTarget(w, r, false)
+		s.logf("proxy: %s %s: no primary available, returning 503", r.Method, r.URL.Path)
+		http.Error(w, "Proxy error: no primary available", http.StatusServiceUnavailable)
 		return
 	}
 


### PR DESCRIPTION
When a non-GET/HEAD request hits the proxy, if there is no primary then the proxy still forwards the request to the target server. However, applications are not expecting to handle primary disconnection since it is delegated to the proxy so the proxy should just return a `503 Service Unavailable` error.