### PR TITLE
Add 'enabled' flag to tracing config

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -57,6 +57,7 @@ func NewConfig() Config {
 
 	config.Log.Format = "text"
 
+	config.Tracing.Enabled = true
 	config.Tracing.MaxSize = DefaultTracingMaxSize
 	config.Tracing.MaxCount = DefaultTracingMaxCount
 	config.Tracing.Compress = DefaultTracingCompress
@@ -181,6 +182,7 @@ const (
 
 // TracingConfig represents the configuration the on-disk trace log.
 type TracingConfig struct {
+	Enabled  bool   `yaml:"enabled"`
 	Path     string `yaml:"path"`
 	MaxSize  int    `yaml:"max-size"`
 	MaxCount int    `yaml:"max-count"`

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -114,7 +114,7 @@ Arguments:
 	// Enable trace logging, if specified. The config settings specify a rolling
 	// on-disk log whereas the CLI flag specifies output to STDOUT.
 	var tw io.Writer
-	if c.Config.Tracing.Path != "" {
+	if c.Config.Tracing.Enabled && c.Config.Tracing.Path != "" {
 		log.Printf("trace log enabled: %s", c.Config.Tracing.Path)
 		tw = &lumberjack.Logger{
 			Filename:   c.Config.Tracing.Path,


### PR DESCRIPTION
Currently, the trace log is enabled when `tracing.path` is set. However, it can be useful to selectively choose which node has tracing enabled.

This PR adds a `tracing.enabled` field which defaults to `true`. If it is `true` and the `tracing.path` is set then the trace log is enabled. This PR was tested manually.

```yml
tracing:
  enabled: ${FLY_REGION == 'syd'}
  path:    "/var/log/litefs/trace.log"
```