### PR TITLE
Expose lag as prometheus metric

### DIFF
--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -359,6 +359,10 @@ func (c *MountCommand) initStore(ctx context.Context) error {
 	if err := c.initStoreBackupClient(ctx); err != nil {
 		return err
 	}
+
+	// Initialize as a singleton so we can automatically collect metrics.
+	litefs.GlobalStore.Store(c.Store)
+
 	return nil
 }
 

--- a/db.go
+++ b/db.go
@@ -3602,7 +3602,7 @@ var (
 	}, []string{"db"})
 
 	dbLatencySecondsMetricVec = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "litefs_db_latency_seconds",
+		Name: "litefs_db_lag_seconds",
 		Help: "Latency between generating an LTX file and consuming it.",
 	}, []string{"db"})
 )


### PR DESCRIPTION
This pull request adds the `litefs_lag_seconds` gauge and returns the lag behind the primary in seconds. This metrics is server-wide as opposed to the per-db `litefs_db_latency_seconds` metric.

It also accounts for heartbeats so replicas that don't receive transactions for more than a second will still have their lag updated. When no transactions are received, a lag of ~1s is normal as that is the heartbeat interval.

The `litefs_db_latency_seconds` metric has been renamed to `litefs_db_lag_seconds` for consistency as well.