### PR TITLE
Proxy health check

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -57,6 +57,8 @@ func NewConfig() Config {
 
 	config.Log.Format = "text"
 
+	config.Proxy.MaxLag = http.DefaultMaxLag
+
 	config.Tracing.Enabled = true
 	config.Tracing.MaxSize = DefaultTracingMaxSize
 	config.Tracing.MaxCount = DefaultTracingMaxCount
@@ -110,11 +112,12 @@ type HTTPConfig struct {
 
 // ProxyConfig represents the configuration for the HTTP proxy server.
 type ProxyConfig struct {
-	Addr        string   `yaml:"addr"`
-	Target      string   `yaml:"target"`
-	DB          string   `yaml:"db"`
-	Debug       bool     `yaml:"debug"`
-	Passthrough []string `yaml:"passthrough"`
+	Addr        string        `yaml:"addr"`
+	Target      string        `yaml:"target"`
+	DB          string        `yaml:"db"`
+	MaxLag      time.Duration `yaml:"max-lag"`
+	Debug       bool          `yaml:"debug"`
+	Passthrough []string      `yaml:"passthrough"`
 }
 
 // LeaseConfig represents a generic configuration for all lease types.

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -503,6 +503,7 @@ func (c *MountCommand) runProxyServer(ctx context.Context) error {
 	server.Target = c.Config.Proxy.Target
 	server.DBName = c.Config.Proxy.DB
 	server.Addr = c.Config.Proxy.Addr
+	server.MaxLag = c.Config.Proxy.MaxLag
 	server.Debug = c.Config.Proxy.Debug
 	server.Passthroughs = passthroughs
 	if err := server.Listen(); err != nil {


### PR DESCRIPTION
This pull request adds a health check endpoint to the LiteFS proxy so that upstream proxies can temporarily remove the node if replication lag exceeds a threshold. This threshold defaults to `10s`.

## litefs.yml

The default threshold is 10 seconds but you can change it in the `proxy` section of the config:

```yml
proxy:
  addr: ":8080"
  target: "localhost:8081"
  db: "my.db"
  max-lag: "5s"
```

If you enable the `proxy.debug` flag then you'll also see debug messages when the proxy fails:

```
proxy: GET /litefs/healthz: current replication lag of 10.7s exceeds maximum threshold of 10s
```

## Fly.io configuration

If you are using Fly.io, see the [fly.toml health checks documentation](https://fly.io/docs/reference/configuration/#http_service-checks). Below is an example:

```
[[http_service.checks]]
  grace_period = "10s"
  interval = "30s"
  method = "GET"
  timeout = "5s"
  path = "/litefs/healthz"
```

