### PR TITLE
Upgrade to Go 1.21

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,11 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
           go-version-file: 'go.mod'
-          cache: true
 
       - name: apt install
         run: sudo apt install -y fuse3 libsqlite3-dev
@@ -38,11 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
           go-version-file: 'go.mod'
-          cache: true
 
       - name: apt install
         run: sudo apt install -y fuse3 libsqlite3-dev consul
@@ -74,11 +70,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
           go-version-file: 'go.mod'
-          cache: true
 
       - name: apt install
         run: sudo apt install -y fuse3 libsqlite3-dev consul
@@ -96,11 +90,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
           go-version-file: 'go.mod'
-          cache: true
 
       - uses: dominikh/staticcheck-action@v1.2.0
         with:
@@ -112,11 +104,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
           go-version-file: 'go.mod'
-          cache: true
 
       - run: go install github.com/kisielk/errcheck@latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
           go-version-file: 'go.mod'
-          cache: true
 
       - id: release
         uses: bruceadams/get-release@v1.3.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 
 WORKDIR /src/litefs
 COPY . .

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 
 WORKDIR /src/litefs
 COPY ../. .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/superfly/litefs
 
-go 1.20
+go 1.21
 
 require (
 	bazil.org/fuse v0.0.0-20230120002735-62a210ff1fd5


### PR DESCRIPTION
This pull request also upgrades [actions/setup-go](https://github.com/actions/setup-go) to v4.