### PR TITLE
Report existing consul cluster ID

### DIFF
--- a/store.go
+++ b/store.go
@@ -749,7 +749,7 @@ func (s *Store) monitorLease(ctx context.Context) (err error) {
 			continue
 
 		} else if leaserClusterID != "" && s.ClusterID() == "" {
-			log.Printf("cannot become primary, local node has no cluster ID and %q lease already initialized", s.Leaser.Type())
+			log.Printf("cannot become primary, local node has no cluster ID and %q lease already initialized with cluster ID %s", s.Leaser.Type(), leaserClusterID)
 
 			if info, err = s.Leaser.PrimaryInfo(ctx); err != nil {
 				log.Printf("cannot find primary, retrying: %s", err)


### PR DESCRIPTION
This pull request adds the cluster ID that Consul has already been initialized with so the user can reset it.

See related: https://community.fly.io/t/trying-to-bring-up-a-machine-after-deleting-its-volume/14806