### PR TITLE
Add set-cluster-id command

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -65,6 +65,9 @@ func run(ctx context.Context, args []string) error {
 		}
 		return c.Run(ctx)
 
+	case "set-cluster-id":
+		return NewSetClusterIDCommand().Run(ctx, args)
+
 	case "version":
 		fmt.Println(VersionString())
 		return nil
@@ -193,10 +196,11 @@ Usage:
 
 The commands are:
 
-	export       export a database from a LiteFS cluster to disk
-	import       import a SQLite database into a LiteFS cluster
-	mount        mount the LiteFS FUSE file system
-	run          executes a subcommand for remote writes
-	version      prints the version
+	export          export a database from a LiteFS cluster to disk
+	import          import a SQLite database into a LiteFS cluster
+	mount           mount the LiteFS FUSE file system
+	run             executes a subcommand for remote writes
+	set-cluster-id  manually updates an existing cluster id
+	version         prints the version
 `[1:])
 }

--- a/cmd/litefs/set_cluster_id.go
+++ b/cmd/litefs/set_cluster_id.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/superfly/litefs/http"
+)
+
+// SetClusterIDCommand represents a command to override the cluster ID.
+type SetClusterIDCommand struct{}
+
+// NewSetClusterIDCommand returns a new instance of SetClusterIDCommand.
+func NewSetClusterIDCommand() *SetClusterIDCommand {
+	return &SetClusterIDCommand{}
+}
+
+// Run executes the command.
+func (c *SetClusterIDCommand) Run(ctx context.Context, args []string) (err error) {
+	fs := flag.NewFlagSet("litefs-set-cluster-id", flag.ContinueOnError)
+	baseURL := fs.String("url", DefaultURL, "LiteFS API URL")
+	fs.Usage = func() {
+		fmt.Println(`
+This command will override the existing cluster id on the node to a new value.
+If configured to use Consul, the value will be updated there as well.
+
+Usage:
+
+	litefs set-cluster-id [arguments] CLUSTERID
+
+Arguments:
+`[1:])
+		fs.PrintDefaults()
+		fmt.Println("")
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if fs.NArg() == 0 {
+		fs.Usage()
+		return flag.ErrHelp
+	} else if fs.NArg() > 1 {
+		return fmt.Errorf("too many arguments")
+	}
+
+	clusterID := fs.Arg(0)
+
+	client := http.NewClient()
+	if err := client.SetClusterID(ctx, *baseURL, clusterID); err != nil {
+		return err
+	}
+
+	fmt.Println("Cluster ID updated.")
+
+	return nil
+}

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -246,17 +246,19 @@ func (l *Leaser) ClusterID(ctx context.Context) (string, error) {
 
 // SetClusterID sets the cluster ID on Consul. The cluster ID can only be set
 // once and it will return an error if attemping to reassign the cluster ID.
-func (l *Leaser) SetClusterID(ctx context.Context, clusterID string) error {
+func (l *Leaser) SetClusterID(ctx context.Context, clusterID string, force bool) error {
 	// Ensure cluster ID has not already been set.
 	//
 	// NOTE: AFAICT, the Consul client doesn't seem to allow CAS operations on
 	// non-existent keys. We could initialize the key to an initializing value
 	// and then replace that, however, this is not a frequent operation so a
 	// race is unlikely.
-	if currentClusterID, err := l.ClusterID(ctx); err != nil {
-		return err
-	} else if currentClusterID != "" {
-		return fmt.Errorf("cluster already initialized, cannot set cluster id")
+	if !force {
+		if currentClusterID, err := l.ClusterID(ctx); err != nil {
+			return err
+		} else if currentClusterID != "" {
+			return fmt.Errorf("cluster already initialized, cannot set cluster id")
+		}
 	}
 
 	// Set our cluster ID. Once set, it can't change.

--- a/http/client.go
+++ b/http/client.go
@@ -190,6 +190,38 @@ func (c *Client) Export(ctx context.Context, primaryURL, name string) (io.ReadCl
 	}
 }
 
+// SetClusterID forces the cluster ID to be updated to the given value.
+func (c *Client) SetClusterID(ctx context.Context, primaryURL string, clusterID string) error {
+	u, err := url.Parse(primaryURL)
+	if err != nil {
+		return fmt.Errorf("invalid client URL: %w", err)
+	} else if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid URL scheme")
+	} else if u.Host == "" {
+		return fmt.Errorf("URL host required")
+	}
+	*u = url.URL{Scheme: u.Scheme, Host: u.Host, Path: "/clusterid"}
+	u.RawQuery = (url.Values{"id": {clusterID}}).Encode()
+
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return err
+	}
+	req = req.WithContext(ctx)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		buf, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("error(%d): %s", resp.StatusCode, buf)
+	}
+	return nil
+}
+
 // Info returns basic information about the node.
 func (c *Client) Info(ctx context.Context, baseURL string) (info litefs.NodeInfo, err error) {
 	u, err := url.Parse(baseURL)

--- a/lease.go
+++ b/lease.go
@@ -32,7 +32,7 @@ type Leaser interface {
 	ClusterID(ctx context.Context) (string, error)
 
 	// SetClusterID sets the cluster ID on the leaser.
-	SetClusterID(ctx context.Context, clusterID string) error
+	SetClusterID(ctx context.Context, clusterID string, force bool) error
 }
 
 // Lease represents an acquired lease from a Leaser.
@@ -137,7 +137,7 @@ func (l *StaticLeaser) ClusterID(ctx context.Context) (string, error) {
 }
 
 // SetClusterID is always a no-op for the static leaser.
-func (l *StaticLeaser) SetClusterID(ctx context.Context, clusterID string) error {
+func (l *StaticLeaser) SetClusterID(ctx context.Context, clusterID string, force bool) error {
 	return nil
 }
 

--- a/mock/lease.go
+++ b/mock/lease.go
@@ -16,7 +16,7 @@ type Leaser struct {
 	AcquireExistingFunc func(ctx context.Context, leaseID string) (litefs.Lease, error)
 	PrimaryInfoFunc     func(ctx context.Context) (litefs.PrimaryInfo, error)
 	ClusterIDFunc       func(ctx context.Context) (string, error)
-	SetClusterIDFunc    func(ctx context.Context, clusterID string) error
+	SetClusterIDFunc    func(ctx context.Context, clusterID string, force bool) error
 }
 
 func (l *Leaser) Close() error {
@@ -45,8 +45,8 @@ func (l *Leaser) ClusterID(ctx context.Context) (string, error) {
 	return l.ClusterIDFunc(ctx)
 }
 
-func (l *Leaser) SetClusterID(ctx context.Context, clusterID string) error {
-	return l.SetClusterIDFunc(ctx, clusterID)
+func (l *Leaser) SetClusterID(ctx context.Context, clusterID string, force bool) error {
+	return l.SetClusterIDFunc(ctx, clusterID, force)
 }
 
 var _ litefs.Lease = (*Lease)(nil)

--- a/store.go
+++ b/store.go
@@ -194,8 +194,8 @@ func (s *Store) ClusterID() string {
 	return s.clusterID.Load().(string)
 }
 
-// setClusterID saves the cluster ID to disk.
-func (s *Store) setClusterID(id string) error {
+// SetClusterID saves the cluster ID to disk.
+func (s *Store) SetClusterID(id string) error {
 	if s.ClusterID() == id {
 		return nil // no-op
 	}
@@ -889,12 +889,12 @@ func (s *Store) monitorLeaseAsPrimary(ctx context.Context, lease Lease) error {
 		}
 
 		// Update the cluster ID on the leaser.
-		if err := s.Leaser.SetClusterID(ctx, clusterID); err != nil {
+		if err := s.Leaser.SetClusterID(ctx, clusterID, false); err != nil {
 			return fmt.Errorf("set leaser cluster id: %w", err)
 		}
 
 		// Save the cluster ID to disk, in case we generated a new one above.
-		if err := s.setClusterID(clusterID); err != nil {
+		if err := s.SetClusterID(clusterID); err != nil {
 			return fmt.Errorf("set local cluster id: %w", err)
 		}
 
@@ -1348,7 +1348,7 @@ func (s *Store) monitorLeaseAsReplica(ctx context.Context, info PrimaryInfo) (ha
 
 	// Adopt cluster ID from primary node if we don't have a cluster ID yet.
 	if s.ClusterID() == "" && st.ClusterID() != "" {
-		if err := s.setClusterID(st.ClusterID()); err != nil {
+		if err := s.SetClusterID(st.ClusterID()); err != nil {
 			return "", fmt.Errorf("set local cluster id: %w", err)
 		}
 	}

--- a/store_test.go
+++ b/store_test.go
@@ -226,7 +226,7 @@ func TestStore_PrimaryCtx(t *testing.T) {
 			ClusterIDFunc: func(ctx context.Context) (string, error) {
 				return clusterID, nil
 			},
-			SetClusterIDFunc: func(ctx context.Context, id string) error {
+			SetClusterIDFunc: func(ctx context.Context, id string, force bool) error {
 				clusterID = id
 				return nil
 			},


### PR DESCRIPTION
This pull request adds the `litefs set-cluster-id` command. It's meant for resetting the cluster ID on a given node as well as Consul. You should run this command on each node in your cluster.

If you are using LiteFS Cloud, you should set the value to the cluster ID reported in this error message:

```
backup client error (422): cluster id mismatch, expecting "LFSC5C7325076A1A2902"
```

Run the command while your LiteFS mount is up and running:

```sh
$ litefs set-cluster-id LFSC5C7325076A1A2902
```