### PR TITLE
Implement soft delete

### DIFF
--- a/backup_client_test.go
+++ b/backup_client_test.go
@@ -27,7 +27,7 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 		if hwm, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
-			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+			Trailer: ltx.Trailer{PostApplyChecksum: 0xe4e4aaa102377eee},
 		})); err != nil {
 			t.Fatal(err)
 		} else if got, want := hwm, ltx.TXID(1); got != want {
@@ -35,17 +35,17 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 		}
 
 		if _, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
-			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 1000},
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: 0xe4e4aaa102377eee},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
-			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
+			Trailer: ltx.Trailer{PostApplyChecksum: 0x99b1d11ab98cc555},
 		})); err != nil {
 			t.Fatal(err)
 		}
 
 		if _, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
-			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 3, MaxTXID: 4, PreApplyChecksum: ltx.ChecksumFlag | 2000},
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 3, MaxTXID: 4, PreApplyChecksum: 0x99b1d11ab98cc555},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{3}, 512)}},
-			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 3000},
+			Trailer: ltx.Trailer{PostApplyChecksum: 0x8b87423eeeeeeeee},
 		})); err != nil {
 			t.Fatal(err)
 		}
@@ -54,7 +54,7 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 		if _, err := c.WriteTx(context.Background(), "db2", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{5}, 512)}},
-			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 5000},
+			Trailer: ltx.Trailer{PostApplyChecksum: 0x99b1d11ab98cc555},
 		})); err != nil {
 			t.Fatal(err)
 		}
@@ -77,8 +77,8 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 				{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)},
 			},
 			Trailer: ltx.Trailer{
-				PostApplyChecksum: ltx.ChecksumFlag | 3000,
-				FileChecksum:      0xbdc35cf8b5a3384c,
+				PostApplyChecksum: 0x8b87423eeeeeeeee,
+				FileChecksum:      0xb8e6a652b0ec8453,
 			},
 		}); !reflect.DeepEqual(got, want) {
 			t.Fatalf("spec mismatch:\ngot:  %#v\nwant: %#v", got, want)
@@ -92,7 +92,7 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 		if _, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
-			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+			Trailer: ltx.Trailer{PostApplyChecksum: 0xe4e4aaa102377eee},
 		})); err != nil {
 			t.Fatal(err)
 		}
@@ -100,12 +100,12 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 		// Write a transaction that doesn't line up with the TXID.
 		var pmErr *ltx.PosMismatchError
 		if _, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
-			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 3, MaxTXID: 3, PreApplyChecksum: ltx.ChecksumFlag | 1000},
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 3, MaxTXID: 3, PreApplyChecksum: 0xe4e4aaa102377eee},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
 		})); !errors.As(err, &pmErr) {
 			t.Fatalf("unexpected error: %s", err)
-		} else if got, want := pmErr.Pos, (ltx.Pos{TXID: 1, PostApplyChecksum: 0x80000000000003e8}); !reflect.DeepEqual(got, want) {
+		} else if got, want := pmErr.Pos, (ltx.Pos{TXID: 1, PostApplyChecksum: 0xe4e4aaa102377eee}); !reflect.DeepEqual(got, want) {
 			t.Fatalf("pos=%s, want %s", got, want)
 		}
 	})
@@ -117,7 +117,7 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 		if _, err := c.WriteTx(context.Background(), "db", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
-			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+			Trailer: ltx.Trailer{PostApplyChecksum: 0xe4e4aaa102377eee},
 		})); err != nil {
 			t.Fatal(err)
 		}
@@ -130,7 +130,7 @@ func TestFileBackupClient_WriteTx(t *testing.T) {
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
 		})); !errors.As(err, &pmErr) {
 			t.Fatalf("unexpected error: %s", err)
-		} else if got, want := pmErr.Pos, (ltx.Pos{TXID: 1, PostApplyChecksum: 0x80000000000003e8}); !reflect.DeepEqual(got, want) {
+		} else if got, want := pmErr.Pos, (ltx.Pos{TXID: 1, PostApplyChecksum: 0xe4e4aaa102377eee}); !reflect.DeepEqual(got, want) {
 			t.Fatalf("pos=%s, want %s", got, want)
 		}
 	})
@@ -158,13 +158,13 @@ func TestFileBackupClient_PosMap(t *testing.T) {
 		if _, err := c.WriteTx(context.Background(), "db1", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{1}, 512)}},
-			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1000},
+			Trailer: ltx.Trailer{PostApplyChecksum: 0xe4e4aaa102377eee},
 		})); err != nil {
 			t.Fatal(err)
 		}
 
 		if _, err := c.WriteTx(context.Background(), "db1", ltxFileSpecReader(t, &ltx.FileSpec{
-			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 1000},
+			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: 0xe4e4aaa102377eee},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{2}, 512)}},
 			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2000},
 		})); err != nil {
@@ -175,7 +175,7 @@ func TestFileBackupClient_PosMap(t *testing.T) {
 		if _, err := c.WriteTx(context.Background(), "db2", ltxFileSpecReader(t, &ltx.FileSpec{
 			Header:  ltx.Header{Version: 1, PageSize: 512, Commit: 1, MinTXID: 1, MaxTXID: 1},
 			Pages:   []ltx.PageSpec{{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{5}, 512)}},
-			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 5000},
+			Trailer: ltx.Trailer{PostApplyChecksum: 0x99b1d11ab98cc555},
 		})); err != nil {
 			t.Fatal(err)
 		}
@@ -185,7 +185,7 @@ func TestFileBackupClient_PosMap(t *testing.T) {
 			t.Fatal(err)
 		} else if got, want := m, map[string]ltx.Pos{
 			"db1": {TXID: 0x2, PostApplyChecksum: 0x80000000000007d0},
-			"db2": {TXID: 0x1, PostApplyChecksum: 0x8000000000001388},
+			"db2": {TXID: 0x1, PostApplyChecksum: 0x99b1d11ab98cc555},
 		}; !reflect.DeepEqual(got, want) {
 			t.Fatalf("map=%#v, want %#v", got, want)
 		}

--- a/client.go
+++ b/client.go
@@ -155,6 +155,8 @@ func (f *EndStreamFrame) Type() StreamFrameType               { return StreamFra
 func (f *EndStreamFrame) ReadFrom(r io.Reader) (int64, error) { return 0, nil }
 func (f *EndStreamFrame) WriteTo(w io.Writer) (int64, error)  { return 0, nil }
 
+// DropDBStreamFrame notifies replicas that a database has been deleted.
+// DEPRECATED: LTX files with a zero "commit" field now represent deletions.
 type DropDBStreamFrame struct {
 	Name string // database name
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,8 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.16-0.20220918133448-90900be5db1a
 	github.com/prometheus/client_golang v1.13.0
 	github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b
-	github.com/superfly/ltx v0.3.3
+	github.com/superfly/ltx v0.3.12
+	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/sys v0.4.0
@@ -45,7 +46,6 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
-	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -307,12 +308,11 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b h1:+WuhtZFB8fNdPeaMUtuB/U8aknXBXdDW/mBm/HTYJNg=
 github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b/go.mod h1:h+GUx1V2s0C5nY73ZN82760eWEJrpMaiDweF31VmJKk=
-github.com/superfly/ltx v0.3.3-0.20230516181327-9fabe139c9c8 h1:h7HBghgAmHDh4GnxZkEdb4hvDHsWBoD2oyDgQRAi0aA=
-github.com/superfly/ltx v0.3.3-0.20230516181327-9fabe139c9c8/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
-github.com/superfly/ltx v0.3.3 h1:dQANl4gg1loocCNEqUghOTPjeWMJySnGu9Sa3D5TVi8=
-github.com/superfly/ltx v0.3.3/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
+github.com/superfly/ltx v0.3.12 h1:Z7z1sc4g34/jUi3XO84+zBlIsbaoh2RJ3b4zTQpBK/M=
+github.com/superfly/ltx v0.3.12/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
+github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
This pull request adds support for soft deleting databases. Previously, deleting a database would wipe it from the primary and then the primary would send a "drop db" frame to the replicas to have them delete as well.

However, this is problematic when connected to LiteFS Cloud (LFSC) for several reasons. First, LFSC acts as the data authority so when the primary removes the database, LiteFS detects that it exists on LFSC and downloads a snapshot, thus negating the delete. Second, LFSC aims to provide durability even in the face of accidental deletion so a delete should not remove old versions of the database.

Changes to LTX (https://github.com/superfly/ltx/pull/46) were made to have a zero-length database represent a deletion. These changes have been integrated into LFSC and this PR integrates it into LiteFS.

/cc @gc-victor

Fixes #382 


## Usage

```sh
# Create a new database on the LiteFS mount.
$ sqlite3 /litefs/db "CREATE TABLE t (x)"

# The new database has a TXID of 1.
$ cat /litefs/db-pos 
0000000000000001/f83db67898d45151

# Removing the database will delete all associated files and will be TXID 2.
$ rm /litefs/db

# The position file will not be visible via "ls" but can be read via "cat"
$ cat /litefs/db-pos 
0000000000000002/8000000000000000

# Re-creating the database will start a new database file. This is TXID 3.
$ sqlite3 /litefs/db "CREATE TABLE my_new_table (y)"

$ cat /litefs/db-pos 
0000000000000003/e01f61ed0d81644e
```
