### PR TITLE
Add snapshot timeout

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -107,7 +107,8 @@ type FUSEConfig struct {
 
 // HTTPConfig represents the configuration for the HTTP server.
 type HTTPConfig struct {
-	Addr string `yaml:"addr"`
+	Addr            string        `yaml:"addr"`
+	SnapshotTimeout time.Duration `yaml:"snapshot-timeout"`
 }
 
 // ProxyConfig represents the configuration for the HTTP proxy server.

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -479,6 +479,7 @@ func (c *MountCommand) initFileSystem(ctx context.Context) error {
 
 func (c *MountCommand) initHTTPServer(ctx context.Context) error {
 	server := http.NewServer(c.Store, c.Config.HTTP.Addr)
+	server.SnapshotTimeout = c.Config.HTTP.SnapshotTimeout
 	if err := server.Listen(); err != nil {
 		return fmt.Errorf("cannot open http server: %w", err)
 	}

--- a/db.go
+++ b/db.go
@@ -3384,6 +3384,12 @@ func (db *DB) WriteSnapshotTo(ctx context.Context, dst io.Writer) (header ltx.He
 	lockPgno := ltx.LockPgno(pageSize)
 	var chksum uint64
 	for pgno := uint32(1); pgno <= pageN; pgno++ {
+		select {
+		case <-ctx.Done():
+			return header, trailer, context.Cause(ctx)
+		default:
+		}
+
 		// Skip the lock page.
 		if pgno == lockPgno {
 			continue


### PR DESCRIPTION
This pull request adds a `snapshot-timeout` configuration to the HTTP server. This prevents slow LTX snapshot writes from holding locks on the database for an excessive period of time. If not specified, it defaults to the retention period since exceeding this period would require the replica to re-snapshot anyway.

## Configuration

```yml
http:
  snapshot-timeout: "5m"
```