### PR TITLE
Make node ID ephemeral

### DIFF
--- a/backup_client.go
+++ b/backup_client.go
@@ -59,7 +59,7 @@ func (c *FileBackupClient) Open() (err error) {
 		return err
 	}
 
-	if err := os.MkdirAll(c.path, 0777); err != nil {
+	if err := os.MkdirAll(c.path, 0o777); err != nil {
 		return err
 	}
 	return nil
@@ -170,7 +170,7 @@ func (c *FileBackupClient) WriteTx(ctx context.Context, name string, r io.Reader
 	// Write file to a temporary file.
 	filename := filepath.Join(c.path, name, ltx.FormatFilename(hdr.MinTXID, hdr.MaxTXID))
 	tempFilename := filename + ".tmp"
-	if err := os.MkdirAll(filepath.Dir(tempFilename), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Dir(tempFilename), 0o777); err != nil {
 		return 0, err
 	}
 	f, err := os.Create(tempFilename)

--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -2370,7 +2370,7 @@ func TestFunctional_OK(t *testing.T) {
 						return
 					}
 
-					t.Logf("%s @ %s: insert", m.Store.LogPrefix(), m.Store.DB("db").Pos())
+					t.Logf("@%s: insert", m.Store.DB("db").Pos())
 					if _, err := db.Exec(`INSERT INTO t (node_id, value) VALUES (?, ?)`, i, strings.Repeat("x", 200)); err != nil {
 						t.Errorf("cannot insert (node %d, iter %d): %s", i, j, err)
 						return
@@ -2388,7 +2388,7 @@ func TestFunctional_OK(t *testing.T) {
 
 					<-ticker.C
 
-					t.Logf("%s @ %s: read", m.Store.LogPrefix(), m.Store.DB("db").Pos())
+					t.Logf("@%s: read", m.Store.DB("db").Pos())
 
 					var id, nodeID int
 					var value string

--- a/store_test.go
+++ b/store_test.go
@@ -159,7 +159,7 @@ func TestPrimaryInfo_Clone(t *testing.T) {
 	})
 }
 
-// Ensure store generates a unique ID that is persistent across restarts.
+// Ensure store generates a unique ID.
 func TestStore_ID(t *testing.T) {
 	store := newStore(t, newPrimaryStaticLeaser(), nil)
 	if err := store.Open(); err != nil {
@@ -171,19 +171,6 @@ func TestStore_ID(t *testing.T) {
 	id := store.ID()
 	if id == 0 {
 		t.Fatal("expected id")
-	}
-
-	// Reopen as a new instance.
-	store = litefs.NewStore(store.Path(), true)
-	store.Leaser = newPrimaryStaticLeaser()
-	if err := store.Open(); err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = store.Close() }()
-
-	// Ensure ID is the same.
-	if got, want := store.ID(), id; got != want {
-		t.Fatalf("id=%d, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
This pull request changes the node ID to be regenerated on startup instead of being persisted to disk. Persisted node IDs caused issues when a volume was cloned as two nodes would end up with the same ID and would not be able to connect to one another. This PR also removes the log prefix from all logging as it mostly cluttered the logs.

Fixes https://github.com/superfly/litefs/issues/361