### PR TITLE
Add event stream

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b h1:+WuhtZFB8fNdPeaMUtuB/U8aknXBXdDW/mBm/HTYJNg=
 github.com/superfly/litefs-go v0.0.0-20230227231337-34ea5dcf1e0b/go.mod h1:h+GUx1V2s0C5nY73ZN82760eWEJrpMaiDweF31VmJKk=
-github.com/superfly/ltx v0.3.12 h1:Z7z1sc4g34/jUi3XO84+zBlIsbaoh2RJ3b4zTQpBK/M=
-github.com/superfly/ltx v0.3.12/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/superfly/ltx v0.3.13 h1:IbuocKJ6sY2jYvZbpUGMYmTkvaLSGUderEZwmaIUmJ0=
 github.com/superfly/ltx v0.3.13/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
This pull request implements the `GET /events` endpoint which provides a newline-delimited stream of JSON objects. Currently, it implements 3 types of events: `init`, `tx`, & `primaryChange`.

/cc @tantaman

## TODO

- [x] Add unit tests
- [x] Add documentation (https://github.com/superfly/docs/pull/968)

## Event Types

### `init`

The `init` event is currently identical to the `primaryChange` event in that it shows information about this primary status. It is always the first event published.

```
{
    "type": "init",
    "data":
    {
        "isPrimary": true,
        "hostname": "myPrimaryHost"
    }
}
```

### `tx`

The `tx` event is published every time a new LTX is written by the node or is received and applied from the primary. 

```
{
    "type": "tx",
    "db": "db",
    "data":
    {
        "txID": "0000000000000027",
        "postApplyChecksum": "83b05248774ce767",
        "pageSize": 4096,
        "commit": 2,
        "timestamp": "2023-09-06T19:12:34.985Z"
    }
}
```

### `primaryChange`

The `primaryChange` event shows information about this primary status. It is delivered when the node becomes primary, loses primary status, connects to a primary, or loses its connection to the primary.

```
{
    "type": "init",
    "data":
    {
        "isPrimary": true,
        "hostname": "myPrimaryHost"
    }
}
```

## Usage

```sh
$ curl localhost:20202/events
{"type":"init","data":{"isPrimary":true}}
{"type":"tx","db":"db","data":{"txID":"0000000000000027","postApplyChecksum":"83b05248774ce767","pageSize":4096,"commit":2,"timestamp":"2023-09-06T19:12:34.985Z"}}
{"type":"tx","db":"db","data":{"txID":"0000000000000028","postApplyChecksum":"8467267f644a1b66","pageSize":4096,"commit":2,"timestamp":"2023-09-06T19:12:39.586Z"}}
```