### PR TITLE
Filter replicated databases

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,7 +22,8 @@ type Client interface {
 	Commit(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64, r io.Reader) error
 
 	// Stream starts a long-running connection to stream changes from another node.
-	Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos) (Stream, error)
+	// If filter is specified, only those databases will be replicated.
+	Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos, filter []string) (Stream, error)
 }
 
 // Stream represents a stream of frames.

--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -150,6 +150,9 @@ type LeaseConfig struct {
 	// become primary again.
 	DemoteDelay time.Duration `yaml:"demote-delay"`
 
+	// Specifies a subset of databases to replica.
+	Databases []string `yaml:"databases"`
+
 	// Consul lease settings.
 	Consul struct {
 		URL       string        `yaml:"url"`

--- a/mock/client.go
+++ b/mock/client.go
@@ -14,7 +14,7 @@ type Client struct {
 	AcquireHaltLockFunc func(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) (*litefs.HaltLock, error)
 	ReleaseHaltLockFunc func(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) error
 	CommitFunc          func(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64, r io.Reader) error
-	StreamFunc          func(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos) (litefs.Stream, error)
+	StreamFunc          func(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos, filter []string) (litefs.Stream, error)
 }
 
 func (c *Client) AcquireHaltLock(ctx context.Context, primaryURL string, nodeID uint64, name string, lockID int64) (*litefs.HaltLock, error) {
@@ -29,8 +29,8 @@ func (c *Client) Commit(ctx context.Context, primaryURL string, nodeID uint64, n
 	return c.CommitFunc(ctx, primaryURL, nodeID, name, lockID, r)
 }
 
-func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos) (litefs.Stream, error) {
-	return c.StreamFunc(ctx, primaryURL, nodeID, posMap)
+func (c *Client) Stream(ctx context.Context, primaryURL string, nodeID uint64, posMap map[string]ltx.Pos, filter []string) (litefs.Stream, error) {
+	return c.StreamFunc(ctx, primaryURL, nodeID, posMap, filter)
 }
 
 type Stream struct {

--- a/store.go
+++ b/store.go
@@ -127,6 +127,9 @@ type Store struct {
 	// Interface to interact with the host environment.
 	Environment Environment
 
+	// Specifies a subset of databases to replicate from the primary.
+	DatabaseFilter []string
+
 	// If true, computes and verifies the checksum of the entire database
 	// after every transaction. Should only be used during testing.
 	StrictVerify bool
@@ -1357,7 +1360,7 @@ func (s *Store) monitorLeaseAsReplica(ctx context.Context, info PrimaryInfo) (ha
 	}()
 
 	posMap := s.PosMap()
-	st, err := s.Client.Stream(ctx, info.AdvertiseURL, s.id, posMap)
+	st, err := s.Client.Stream(ctx, info.AdvertiseURL, s.id, posMap, s.DatabaseFilter)
 	if err != nil {
 		return "", fmt.Errorf("connect to primary: %s ('%s')", err, info.AdvertiseURL)
 	}

--- a/store_test.go
+++ b/store_test.go
@@ -220,7 +220,7 @@ func TestStore_PrimaryCtx(t *testing.T) {
 		}
 
 		client := mock.Client{
-			StreamFunc: func(ctx context.Context, rawurl string, nodeID uint64, posMap map[string]ltx.Pos) (litefs.Stream, error) {
+			StreamFunc: func(ctx context.Context, rawurl string, nodeID uint64, posMap map[string]ltx.Pos, filter []string) (litefs.Stream, error) {
 				return &mock.Stream{
 					ReadCloser:    io.NopCloser(&bytes.Buffer{}),
 					ClusterIDFunc: func() string { return "" },
@@ -253,7 +253,7 @@ func TestStore_PrimaryCtx(t *testing.T) {
 	t.Run("InitialReplica", func(t *testing.T) {
 		leaser := litefs.NewStaticLeaser(false, "localhost", "http://localhost:20202")
 		client := mock.Client{
-			StreamFunc: func(ctx context.Context, rawurl string, nodeID uint64, posMap map[string]ltx.Pos) (litefs.Stream, error) {
+			StreamFunc: func(ctx context.Context, rawurl string, nodeID uint64, posMap map[string]ltx.Pos, filter []string) (litefs.Stream, error) {
 				var buf bytes.Buffer
 				if err := litefs.WriteStreamFrame(&buf, &litefs.ReadyStreamFrame{}); err != nil {
 					return nil, err


### PR DESCRIPTION
As discussed in [this Community forum post](https://community.fly.io/t/litefs-multiple-databases/15595/6), this PR adds a config option to specify a subset of databases to be replicated to a specific replica. Please note that this config option is only allowed on non-candidate nodes! If we allowed it on candidate nodes then it would delete the other databases when the node became primary.

## Usage

To use the filter, specify it with the `lease.databases` config field:

```yml
lease:
  candidate: false  # Must not be a candidate, otherwise will error out on startup
  databases: ["foo.db", "bar.db"]
```

or you can use the multiline array format:

```yml
lease:
  databases: 
    - "foo.db"
    - "bar.db"
```