### PR TITLE
Proxy primary redirect timeout

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -58,6 +58,7 @@ func NewConfig() Config {
 	config.Log.Format = "text"
 
 	config.Proxy.MaxLag = http.DefaultMaxLag
+	config.Proxy.PrimaryRedirectTimeout = http.DefaultPrimaryRedirectTimeout
 
 	config.Tracing.Enabled = true
 	config.Tracing.MaxSize = DefaultTracingMaxSize
@@ -113,12 +114,13 @@ type HTTPConfig struct {
 
 // ProxyConfig represents the configuration for the HTTP proxy server.
 type ProxyConfig struct {
-	Addr        string        `yaml:"addr"`
-	Target      string        `yaml:"target"`
-	DB          string        `yaml:"db"`
-	MaxLag      time.Duration `yaml:"max-lag"`
-	Debug       bool          `yaml:"debug"`
-	Passthrough []string      `yaml:"passthrough"`
+	Addr                   string        `yaml:"addr"`
+	Target                 string        `yaml:"target"`
+	DB                     string        `yaml:"db"`
+	MaxLag                 time.Duration `yaml:"max-lag"`
+	Debug                  bool          `yaml:"debug"`
+	Passthrough            []string      `yaml:"passthrough"`
+	PrimaryRedirectTimeout time.Duration `yaml:"primary-redirect-timeout"`
 }
 
 // LeaseConfig represents a generic configuration for all lease types.

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -529,6 +529,7 @@ func (c *MountCommand) runProxyServer(ctx context.Context) error {
 	server.MaxLag = c.Config.Proxy.MaxLag
 	server.Debug = c.Config.Proxy.Debug
 	server.Passthroughs = passthroughs
+	server.PrimaryRedirectTimeout = c.Config.Proxy.PrimaryRedirectTimeout
 	if err := server.Listen(); err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request changes the HTTP proxy so that it will wait until it has primary information before attempting to redirect. It will wait up to 5 seconds by default but this can be changed in the config.

Fixes https://github.com/superfly/litefs/issues/406

## Config

To change the primary redirect timeout, you can specify it in the `proxy` section of the config:

```yml
proxy:
  addr: ":8080"
  target: "localhost:8081"
  db: "my.db"
  primary-redirect-timeout: "10s"
```

