### PR TITLE
Add always-forward config to proxy server

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -120,6 +120,7 @@ type ProxyConfig struct {
 	MaxLag                 time.Duration `yaml:"max-lag"`
 	Debug                  bool          `yaml:"debug"`
 	Passthrough            []string      `yaml:"passthrough"`
+	AlwaysForward          []string      `yaml:"always-forward"`
 	PrimaryRedirectTimeout time.Duration `yaml:"primary-redirect-timeout"`
 }
 

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -522,6 +522,16 @@ func (c *MountCommand) runProxyServer(ctx context.Context) error {
 		passthroughs = append(passthroughs, re)
 	}
 
+	// Parse always-forward expressions.
+	var alwaysForward []*regexp.Regexp
+	for _, s := range c.Config.Proxy.AlwaysForward {
+		re, err := http.CompileMatch(s)
+		if err != nil {
+			return fmt.Errorf("cannot parse proxy always-forward expression: %q", s)
+		}
+		alwaysForward = append(alwaysForward, re)
+	}
+
 	server := http.NewProxyServer(c.Store)
 	server.Target = c.Config.Proxy.Target
 	server.DBName = c.Config.Proxy.DB
@@ -529,6 +539,7 @@ func (c *MountCommand) runProxyServer(ctx context.Context) error {
 	server.MaxLag = c.Config.Proxy.MaxLag
 	server.Debug = c.Config.Proxy.Debug
 	server.Passthroughs = passthroughs
+	server.AlwaysForward = alwaysForward
 	server.PrimaryRedirectTimeout = c.Config.Proxy.PrimaryRedirectTimeout
 	if err := server.Listen(); err != nil {
 		return err


### PR DESCRIPTION
This pull request adds a proxy config setting to specify regex-matching paths to always forward to the primary (even when using `GET` & `HEAD` methods). This was proposed on [this Fly.io Community forum post](https://community.fly.io/t/litefs-http-proxy-failing-with-nextauth/15917/3).

## Usage

```yaml
proxy:
  always-forward:
    - "^/my/path$"
    - "^/my/other/path$"
```