### PR TITLE
Default data dir & FUSE dir

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -17,6 +17,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	DefaultDataDir = "/var/lib/litefs"
+	DefaultFUSEDir = "/litefs"
+)
+
 // NOTE: Update etc/litefs.yml configuration file after changing the structure below.
 
 // Config represents a configuration for the binary process.
@@ -42,9 +47,12 @@ func NewConfig() Config {
 	var config Config
 	config.ExitOnError = true
 
+	config.Data.Dir = DefaultDataDir
 	config.Data.Compress = true
 	config.Data.Retention = litefs.DefaultRetention
 	config.Data.RetentionMonitorInterval = litefs.DefaultRetentionMonitorInterval
+
+	config.FUSE.Dir = DefaultFUSEDir
 
 	config.HTTP.Addr = http.DefaultAddr
 

--- a/cmd/litefs/mount_test.go
+++ b/cmd/litefs/mount_test.go
@@ -2702,6 +2702,7 @@ func TestFunctional_OK(t *testing.T) {
 func TestMountCommand_Validate(t *testing.T) {
 	t.Run("ErrFUSEDirectoryRequired", func(t *testing.T) {
 		cmd := main.NewMountCommand()
+		cmd.Config.FUSE.Dir = ""
 		if err := cmd.Validate(context.Background()); err == nil || err.Error() != `fuse directory required` {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -2709,6 +2710,7 @@ func TestMountCommand_Validate(t *testing.T) {
 	t.Run("ErrDataDirectoryRequired", func(t *testing.T) {
 		cmd := main.NewMountCommand()
 		cmd.Config.FUSE.Dir = t.TempDir()
+		cmd.Config.Data.Dir = ""
 		if err := cmd.Validate(context.Background()); err == nil || err.Error() != `data directory required` {
 			t.Fatalf("unexpected error: %s", err)
 		}


### PR DESCRIPTION
This pull request sets defaults for the `litefs.yml` as follows:

```yml
data:
  dir: "/var/lib/litefs"

fuse:
  dir: "/litefs"
```