### PR TITLE
Add proxy server timeout config options

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -67,6 +67,10 @@ func NewConfig() Config {
 
 	config.Proxy.MaxLag = http.DefaultMaxLag
 	config.Proxy.PrimaryRedirectTimeout = http.DefaultPrimaryRedirectTimeout
+	config.Proxy.ReadTimeout = http.DefaultReadTimeout
+	config.Proxy.ReadHeaderTimeout = http.DefaultReadHeaderTimeout
+	config.Proxy.WriteTimeout = http.DefaultWriteTimeout
+	config.Proxy.IdleTimeout = http.DefaultIdleTimeout
 
 	config.Tracing.Enabled = true
 	config.Tracing.MaxSize = DefaultTracingMaxSize
@@ -130,6 +134,11 @@ type ProxyConfig struct {
 	Passthrough            []string      `yaml:"passthrough"`
 	AlwaysForward          []string      `yaml:"always-forward"`
 	PrimaryRedirectTimeout time.Duration `yaml:"primary-redirect-timeout"`
+
+	ReadTimeout       time.Duration `yaml:"read-timeout"`
+	ReadHeaderTimeout time.Duration `yaml:"read-header-timeout"`
+	WriteTimeout      time.Duration `yaml:"write-timeout"`
+	IdleTimeout       time.Duration `yaml:"idle-timeout"`
 }
 
 // LeaseConfig represents a generic configuration for all lease types.

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -541,6 +541,11 @@ func (c *MountCommand) runProxyServer(ctx context.Context) error {
 	server.Passthroughs = passthroughs
 	server.AlwaysForward = alwaysForward
 	server.PrimaryRedirectTimeout = c.Config.Proxy.PrimaryRedirectTimeout
+	server.ReadTimeout = c.Config.Proxy.ReadTimeout
+	server.ReadHeaderTimeout = c.Config.Proxy.ReadHeaderTimeout
+	server.WriteTimeout = c.Config.Proxy.WriteTimeout
+	server.IdleTimeout = c.Config.Proxy.IdleTimeout
+
 	if err := server.Listen(); err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request adds several HTTP server timeout options to the `proxy` section of the config:

```yml
proxy:
  read-timeout = "0s"
  read-header-timeout = "10s"
  write-timeout = "0s"
  idle-timeout = "30s"
```

These correspond to the timeouts listed in the [http.Server](https://pkg.go.dev/net/http#Server) docs.