### PR TITLE
Dockerfile: Add sidecar support

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -23,10 +23,10 @@ jobs:
       VERSION: "${{ github.event_name == 'release' && github.event.release.name || github.ref_name }}"
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/login-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
         id: login
         env:
           token_is_present: "${{ secrets.DOCKERHUB_TOKEN && true }}"
@@ -36,7 +36,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: flyio/litefs
           tags: |
@@ -47,7 +47,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - uses: docker/build-push-action@v4
+      - uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ steps.login.outcome != 'skipped' }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -53,14 +53,14 @@ jobs:
         run: go test -v . ./internal/...
 
       - name: Run FUSE tests
-        run: go test -v -p 1 -timeout 5m ./fuse -long -journal-mode ${{ matrix.journal_mode }}
+        run: go test -v -p 1 -timeout 10m ./fuse -long -journal-mode ${{ matrix.journal_mode }}
         timeout-minutes: 5
 
       - name: Start consul in dev mode
         run: consul agent -dev &
 
       - name: Run cmd tests
-        run: go test -v -p 1 -timeout 5m ./cmd/litefs -journal-mode ${{ matrix.journal_mode }}
+        run: go test -v -p 1 -timeout 10m ./cmd/litefs -journal-mode ${{ matrix.journal_mode }}
         timeout-minutes: 5
 
   functional:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,9 +14,9 @@ jobs:
     name: "Build"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 
@@ -34,9 +34,9 @@ jobs:
       matrix:
         journal_mode: [delete, persist, truncate, wal]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 
@@ -71,9 +71,9 @@ jobs:
       matrix:
         journal_mode: [delete, persist, truncate, wal]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 
@@ -94,13 +94,13 @@ jobs:
     name: "Staticcheck"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 
-      - uses: dominikh/staticcheck-action@v1.2.0
+      - uses: dominikh/staticcheck-action@v1.3.1
         with:
           install-go: false
 
@@ -108,9 +108,9 @@ jobs:
     name: "Errcheck"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
       MAIN_VERSION: "${{ github.event_name == 'release' && github.event.release.name || '' }}"
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 
@@ -62,7 +62,7 @@ jobs:
           tar -czvf litefs-${{ env.VERSION }}-${{ env.GOOS }}-${{ env.GOARCH }}${{ env.GOARM }}.tar.gz litefs
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: litefs-${{ env.VERSION }}-${{ env.GOOS }}-${{ env.GOARCH }}${{ env.GOARM }}
           path: dist/litefs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.5 as builder
+FROM golang:1.21.5 AS builder
 
 WORKDIR /src/litefs
 COPY . .
@@ -10,8 +10,11 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 	--mount=type=cache,target=/go/pkg \
 	go build -ldflags "-s -w -X 'main.Version=${LITEFS_VERSION}' -X 'main.Commit=${LITEFS_COMMIT}' -extldflags '-static'" -tags osusergo,netgo,sqlite_omit_load_extension -o /usr/local/bin/litefs ./cmd/litefs
 
+FROM alpine
 
-FROM scratch
+RUN apk add --no-cache fuse3
+
 COPY --from=builder /usr/local/bin/litefs /usr/local/bin/litefs
+
 ENTRYPOINT ["/usr/local/bin/litefs"]
-CMD []
+CMD ["mount", "-skip-unmount"]

--- a/fuse/file_system.go
+++ b/fuse/file_system.go
@@ -58,9 +58,11 @@ func (fsys *FileSystem) Path() string { return fsys.path }
 func (fsys *FileSystem) Store() *litefs.Store { return fsys.store }
 
 // Mount mounts the file system to the mount point.
-func (fsys *FileSystem) Mount() (err error) {
-	// Attempt to unmount if it did not close cleanly before.
-	_ = fuse.Unmount(fsys.path)
+func (fsys *FileSystem) Mount(skipUnmount bool) (err error) {
+	if !skipUnmount {
+		// Attempt to unmount if it did not close cleanly before.
+		_ = fuse.Unmount(fsys.path)
+	}
 
 	// Ensure mount directory exists before trying to mount to it.
 	if err := os.MkdirAll(fsys.path, 0777); err != nil {

--- a/fuse/file_system_test.go
+++ b/fuse/file_system_test.go
@@ -927,7 +927,7 @@ func newOpenFileSystem(tb testing.TB, path string, leaser *litefs.StaticLeaser) 
 	tb.Helper()
 
 	fs := newFileSystem(tb, path, leaser)
-	if err := fs.Mount(); err != nil {
+	if err := fs.Mount(false); err != nil {
 		tb.Fatalf("cannot open file system: %s", err)
 	}
 


### PR DESCRIPTION
This PR adds support for using the LiteFS container as a sidecar, when used in a container runtime that supports mount propagation (e.g. filesystems mounted inside one container can be propagated to the host or other containers).

- It adds the required `fusermount3` binary
- It adds a `-skip-unmount` argument to `litefs mount`, and uses that as the container command. When mounting on top of an existing mountpoint, LiteFS would unconditionally unmount it. This would break mount propagation, so we want to avoid this behavior.

Fixes https://github.com/superfly/litefs/issues/365