### PR TITLE
http: add Secure flag to TXID cookie

### DIFF
--- a/cmd/litefs/config.go
+++ b/cmd/litefs/config.go
@@ -135,6 +135,8 @@ type ProxyConfig struct {
 	AlwaysForward          []string      `yaml:"always-forward"`
 	PrimaryRedirectTimeout time.Duration `yaml:"primary-redirect-timeout"`
 
+	SecureCookie *bool `yaml:"secure-cookie"`
+
 	ReadTimeout       time.Duration `yaml:"read-timeout"`
 	ReadHeaderTimeout time.Duration `yaml:"read-header-timeout"`
 	WriteTimeout      time.Duration `yaml:"write-timeout"`

--- a/cmd/litefs/mount_linux.go
+++ b/cmd/litefs/mount_linux.go
@@ -556,6 +556,9 @@ func (c *MountCommand) runProxyServer(ctx context.Context) error {
 	server.ReadHeaderTimeout = c.Config.Proxy.ReadHeaderTimeout
 	server.WriteTimeout = c.Config.Proxy.WriteTimeout
 	server.IdleTimeout = c.Config.Proxy.IdleTimeout
+	if c.Config.Proxy.SecureCookie != nil {
+		server.SecureCookie = *c.Config.Proxy.SecureCookie
+	}
 
 	if err := server.Listen(); err != nil {
 		return err

--- a/http/proxy_server.go
+++ b/http/proxy_server.go
@@ -81,6 +81,11 @@ type ProxyServer struct {
 	// Time before cookie expires on client.
 	CookieExpiry time.Duration
 
+	// If true, set the Secure flag on the TXID cookie so that it is only
+	// sent over HTTPS connections. Defaults to true since LiteFS typically
+	// runs behind a TLS-terminating reverse proxy.
+	SecureCookie bool
+
 	// HTTP server timeouts
 	ReadTimeout       time.Duration
 	ReadHeaderTimeout time.Duration
@@ -99,6 +104,7 @@ func NewProxyServer(store *litefs.Store) *ProxyServer {
 		PollTXIDTimeout:        DefaultPollTXIDTimeout,
 		MaxLag:                 DefaultMaxLag,
 		CookieExpiry:           DefaultCookieExpiry,
+		SecureCookie:           true,
 		PrimaryRedirectTimeout: DefaultPrimaryRedirectTimeout,
 		ReadTimeout:            DefaultReadTimeout,
 		ReadHeaderTimeout:      DefaultReadHeaderTimeout,
@@ -331,6 +337,7 @@ func (s *ProxyServer) proxyToTarget(w http.ResponseWriter, r *http.Request, pass
 				Path:     "/",
 				Expires:  time.Now().Add(s.CookieExpiry),
 				HttpOnly: true,
+				Secure:   s.SecureCookie,
 			})
 		}
 	}


### PR DESCRIPTION
The __txid cookie was being set without the Secure flag, allowing it to be transmitted over unencrypted connections. Since LiteFS typically runs behind a TLS-terminating reverse proxy, default SecureCookie to true so the cookie is only sent over HTTPS.

A "secure-cookie" option is added to the proxy YAML config so that users running local development without TLS can explicitly disable it.

Fixes #440